### PR TITLE
iosxr_users: fix type validation for groups

### DIFF
--- a/plugins/modules/iosxr_user.py
+++ b/plugins/modules/iosxr_user.py
@@ -813,7 +813,7 @@ def main():
         public_key=dict(),
         public_key_contents=dict(),
         group=dict(aliases=["role"]),
-        groups=dict(type="list", elements="dict"),
+        groups=dict(type="list", elements="str"),
         state=dict(default="present", choices=["present", "absent"]),
     )
     aggregate_spec = deepcopy(element_spec)


### PR DESCRIPTION
##### SUMMARY

Following the documentation, groups should be a list of strings.
Moreover, the code also assume this is a list of strings (iterate on
it and append to a string). However, when providing a list of strings,
the module complains it expects a list of dict:

    Elements value for option groups is of type <class 'str'> and we were
    unable to convert to dict: dictionary requested, could not parse JSON
    or key=value

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`iosxr_user`
