### PR TITLE
Provide Functionality to utilize "#" to remark(prefix-set) with iosxr_config Module

### DIFF
--- a/changelogs/fragments/provide_fuctionality_to_utilize_remarks.yaml
+++ b/changelogs/fragments/provide_fuctionality_to_utilize_remarks.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Platform supported coments token to be provided when invoking the object.

--- a/plugins/cliconf/iosxr.py
+++ b/plugins/cliconf/iosxr.py
@@ -197,7 +197,7 @@ class Cliconf(CliconfBase):
 
         # prepare candidate configuration
         sanitized_candidate = sanitize_config(candidate)
-        candidate_obj = NetworkConfig(indent=1)
+        candidate_obj = NetworkConfig(indent=1, comment_tokens=["!"])
         candidate_obj.load(sanitized_candidate)
 
         if running and diff_match != "none":
@@ -208,7 +208,10 @@ class Cliconf(CliconfBase):
             running = sanitize_config(running)
 
             running_obj = NetworkConfig(
-                indent=1, contents=running, ignore_lines=diff_ignore_lines
+                indent=1,
+                contents=running,
+                ignore_lines=diff_ignore_lines,
+                comment_tokens=["!"],
             )
             configdiffobjs = candidate_obj.difference(
                 running_obj, path=path, match=diff_match, replace=diff_replace

--- a/plugins/module_utils/network/iosxr/iosxr.py
+++ b/plugins/module_utils/network/iosxr/iosxr.py
@@ -135,12 +135,15 @@ CONFIG_MISPLACED_CHILDREN = [re.compile(r"^end-\s*(.+)$")]
 # Hence these objects should be played direcly from candidate
 # configurations
 CONFIG_BLOCKS_FORCED_IN_DIFF = [
-    {"start": re.compile(r"route-policy"), "end": re.compile(r"end-policy")},
-    {"start": re.compile(r"prefix-set"), "end": re.compile(r"end-set")},
-    {"start": re.compile(r"as-path-set"), "end": re.compile(r"end-set")},
-    {"start": re.compile(r"community-set"), "end": re.compile(r"end-set")},
-    {"start": re.compile(r"rd-set"), "end": re.compile(r"end-set")},
-    {"start": re.compile(r"extcommunity-set"), "end": re.compile(r"end-set")},
+    {"start": re.compile(r"^route-policy"), "end": re.compile(r"end-policy$")},
+    {"start": re.compile(r"^prefix-set"), "end": re.compile(r"end-set$")},
+    {"start": re.compile(r"^as-path-set"), "end": re.compile(r"end-set$")},
+    {"start": re.compile(r"^community-set"), "end": re.compile(r"end-set$")},
+    {"start": re.compile(r"^rd-set"), "end": re.compile(r"end-set$")},
+    {
+        "start": re.compile(r"^extcommunity-set"),
+        "end": re.compile(r"end-set$"),
+    },
 ]
 
 
@@ -640,7 +643,7 @@ def mask_config_blocks_from_diff(config, candidate, force_diff_prefix):
                             # otherwise we would be having new start
                             new_block = False
                             break
-                    if new_block:
+                    if new_block and start_index:
                         block_index_start_end.append((start_index, end_index))
 
         for start, end in block_index_start_end:

--- a/plugins/modules/iosxr_config.py
+++ b/plugins/modules/iosxr_config.py
@@ -317,7 +317,7 @@ def get_candidate(module):
     if module.params["src"]:
         candidate = module.params["src"]
     elif module.params["lines"]:
-        candidate_obj = NetworkConfig(indent=1)
+        candidate_obj = NetworkConfig(indent=1, comment_tokens=["!"])
         parents = module.params["parents"] or list()
         candidate_obj.add(module.params["lines"], parents=parents)
         candidate = dumps(candidate_obj, "raw")

--- a/tests/integration/targets/iosxr_config/tests/cli/prefix_set_remark.yaml
+++ b/tests/integration/targets/iosxr_config/tests/cli/prefix_set_remark.yaml
@@ -1,0 +1,29 @@
+---
+- debug: msg="START cli/prefix_set_remark.yaml on connection={{ ansible_connection }}"
+
+- name: pre-setup cleanup
+  cisco.iosxr.iosxr_config:
+    commands:
+      - no prefix-set test_set
+
+- name: setup
+  register: result
+  cisco.iosxr.iosxr_config:
+    lines:
+      - '#testremark'
+      - 192.168.1.0/20 le 24
+      - end-set
+    parents: prefix-set test_set
+
+- assert:
+    that:
+      - result.changed == true
+      - "'#testremark' in result.commands"
+
+- name: post-setup cleanup
+  cisco.iosxr.iosxr_config:
+    commands:
+      - no prefix-set test_set
+
+
+- debug: msg="END cli/prefix_set_remark.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
Signed-off-by: Rohit Thakur <rohitthakur2590@outlook.com>
Depends-On: https://github.com/ansible-collections/ansible.netcommon/pull/110
Should help to resolve: https://github.com/ansible/ansible/issues/57130 
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Passing the  `comment_tokens`  list while Invoking the NetworkConfig object .
which will override default comment_tokens list
 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
 

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
 plugins/cliconf/iosxr.py
 plugins/module_utils/network/iosxr/iosxr.py
plugins/modules/iosxr_config.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
