### PR TITLE
Fix commit timeout failure issue for netconf modules

### DIFF
--- a/changelogs/fragments/iosxr_netconf_config_commit_fix.yaml
+++ b/changelogs/fragments/iosxr_netconf_config_commit_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Confirmed commit fails with TypeError in IOS XR netconf plugin (https://github.com/ansible-collections/cisco.iosxr/issues/74)

--- a/changelogs/fragments/iosxr_netconf_config_commit_fix.yaml
+++ b/changelogs/fragments/iosxr_netconf_config_commit_fix.yaml
@@ -1,2 +1,4 @@
+---
 bugfixes:
-- Confirmed commit fails with TypeError in IOS XR netconf plugin (https://github.com/ansible-collections/cisco.iosxr/issues/74)
+  - Confirmed commit fails with TypeError in IOS XR netconf plugin
+    (https://github.com/ansible-collections/cisco.iosxr/issues/74)

--- a/plugins/netconf/iosxr.py
+++ b/plugins/netconf/iosxr.py
@@ -255,7 +255,7 @@ class Netconf(NetconfBase):
     def commit(
         self, confirmed=False, timeout=None, persist=None, remove_ns=False
     ):
-        timeout = to_text(timeout, errors='surrogate_or_strict')
+        timeout = to_text(timeout, errors="surrogate_or_strict")
         try:
             resp = self.m.commit(
                 confirmed=confirmed, timeout=timeout, persist=persist

--- a/plugins/netconf/iosxr.py
+++ b/plugins/netconf/iosxr.py
@@ -43,7 +43,7 @@ import json
 import re
 import collections
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_native, to_text
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.netconf import (
     remove_namespaces,
 )
@@ -255,6 +255,7 @@ class Netconf(NetconfBase):
     def commit(
         self, confirmed=False, timeout=None, persist=None, remove_ns=False
     ):
+        timeout = to_text(timeout, errors='surrogate_or_strict')
         try:
             resp = self.m.commit(
                 confirmed=confirmed, timeout=timeout, persist=persist


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible-collections/cisco.iosxr/issues/74

*  ncclient API expects commit timeout value in either unicode
   or bytes format, hence convert the timeout value explicitly
   to string type.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
 plugins/netconf/iosxr.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
