### PR TITLE
Fix a timeout when deploying multi line banners.

### DIFF
--- a/changelogs/fragments/79-iosxr-multi-line-banner-fix.yaml
+++ b/changelogs/fragments/79-iosxr-multi-line-banner-fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - require one to specify a banner delimiter in order to fix a timeout when using multi-line strings

--- a/plugins/modules/iosxr_banner.py
+++ b/plugins/modules/iosxr_banner.py
@@ -81,7 +81,7 @@ commands:
   type: list
   sample:
     - banner login
-    - @this is my login banner
+    - "@this is my login banner"
     - that contains a multiline
     - string@
 

--- a/tests/integration/targets/iosxr_banner/tests/cli/basic-login.yaml
+++ b/tests/integration/targets/iosxr_banner/tests/cli/basic-login.yaml
@@ -9,7 +9,7 @@
   register: result
   cisco.iosxr.iosxr_banner:
     banner: login
-    text: "this is my login banner\nthat has a multiline\nstring\n"
+    text: "@this is my login banner\nthat has a multiline\nstring\n@"
     provider: '{{ cli }}'
     state: present
 
@@ -26,7 +26,7 @@
   register: result
   cisco.iosxr.iosxr_banner:
     banner: login
-    text: "this is my login banner\nthat has a multiline\nstring\n"
+    text: "@this is my login banner\nthat has a multiline\nstring\n@"
     provider: '{{ cli }}'
     state: present
 

--- a/tests/integration/targets/iosxr_banner/tests/cli/basic-motd.yaml
+++ b/tests/integration/targets/iosxr_banner/tests/cli/basic-motd.yaml
@@ -9,7 +9,7 @@
   register: result
   cisco.iosxr.iosxr_banner:
     banner: motd
-    text: "this is my motd banner\nthat has a multiline\nstring\n"
+    text: "@this is my motd banner\nthat has a multiline\nstring\n@"
     provider: '{{ cli }}'
     state: present
 
@@ -26,7 +26,7 @@
   register: result
   cisco.iosxr.iosxr_banner:
     banner: motd
-    text: "this is my motd banner\nthat has a multiline\nstring\n"
+    text: "@this is my motd banner\nthat has a multiline\nstring\n@"
     provider: '{{ cli }}'
     state: present
 

--- a/tests/integration/targets/iosxr_banner/tests/cli/basic-no-login.yaml
+++ b/tests/integration/targets/iosxr_banner/tests/cli/basic-no-login.yaml
@@ -2,7 +2,7 @@
 - name: Setup
   cisco.iosxr.iosxr_banner:
     banner: login
-    text: "Junk login banner\nover multiple lines\n"
+    text: "@Junk login banner\nover multiple lines\n@"
     provider: '{{ cli }}'
     state: present
 

--- a/tests/integration/targets/iosxr_banner/tests/netconf/basic-login.yaml
+++ b/tests/integration/targets/iosxr_banner/tests/netconf/basic-login.yaml
@@ -9,7 +9,7 @@
   register: result
   cisco.iosxr.iosxr_banner:
     banner: login
-    text: "this is my login banner\nthat has a multiline\nstring\n"
+    text: "@this is my login banner\nthat has a multiline\nstring\n@"
     provider: '{{ netconf }}'
     state: present
 
@@ -26,7 +26,7 @@
   register: result
   cisco.iosxr.iosxr_banner:
     banner: login
-    text: "this is my login banner\nthat has a multiline\nstring\n"
+    text: "@this is my login banner\nthat has a multiline\nstring\n@"
     provider: '{{ netconf }}'
     state: present
 

--- a/tests/integration/targets/iosxr_banner/tests/netconf/basic-motd.yaml
+++ b/tests/integration/targets/iosxr_banner/tests/netconf/basic-motd.yaml
@@ -9,7 +9,7 @@
   register: result
   cisco.iosxr.iosxr_banner:
     banner: motd
-    text: "this is my motd banner\nthat has a multiline\nstring\n"
+    text: "@this is my motd banner\nthat has a multiline\nstring\n@"
     provider: '{{ netconf }}'
     state: present
 
@@ -26,7 +26,7 @@
   register: result
   cisco.iosxr.iosxr_banner:
     banner: motd
-    text: "this is my motd banner\nthat has a multiline\nstring\n"
+    text: "@this is my motd banner\nthat has a multiline\nstring\n@"
     provider: '{{ netconf }}'
     state: present
 

--- a/tests/integration/targets/iosxr_banner/tests/netconf/basic-no-login.yaml
+++ b/tests/integration/targets/iosxr_banner/tests/netconf/basic-no-login.yaml
@@ -2,7 +2,7 @@
 - name: Setup
   cisco.iosxr.iosxr_banner:
     banner: login
-    text: "Junk login banner\nover multiple lines\n"
+    text: "@Junk login banner\nover multiple lines\n@"
     provider: '{{ netconf }}'
     state: present
 


### PR DESCRIPTION
Banner text was being sent in repr() format which trips up the IOS-XR
CLI causing it to hang at the prompt waiting for the banner termination
character.  Instead of trying to wrap the banner in ', put it on the
user to specify their own delimiter character.

##### SUMMARY
This is believed to fix issue #77 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
iosxr_banner