### PR TITLE
Remove ansible from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-ansible
 lxml
 ncclient
 paramiko


### PR DESCRIPTION
Due to how ansible / ansible-base works, this actually breaks testing of
ansible/ansible devel.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>