### PR TITLE
Add support single_user_mode

### DIFF
--- a/changelogs/fragments/single_user_mode.yaml
+++ b/changelogs/fragments/single_user_mode.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+ - Add support for single_user_mode.
+ - Re-use device_info dict instead of building it every time.

--- a/plugins/cliconf/iosxr.py
+++ b/plugins/cliconf/iosxr.py
@@ -108,20 +108,20 @@ class Cliconf(CliconfBase):
         ).strip()
         if not prompt.endswith(")#"):
             if admin and "admin-" not in prompt:
-                self._connection.send_command("admin")
+                self.send_command("admin")
             if exclusive:
-                self._connection.send_command("configure exclusive")
+                self.send_command("configure exclusive")
                 return
-            self._connection.send_command("configure terminal")
+            self.send_command("configure terminal")
 
     def abort(self, admin=False):
         prompt = to_text(
             self._connection.get_prompt(), errors="surrogate_or_strict"
         ).strip()
         if prompt.endswith(")#"):
-            self._connection.send_command("abort")
+            self.send_command("abort")
             if admin and "admin-" in prompt:
-                self._connection.send_command("exit")
+                self.send_command("exit")
 
     def get_config(self, source="running", format="text", flags=None):
         if source not in ["running"]:
@@ -135,7 +135,7 @@ class Cliconf(CliconfBase):
         cmd += " ".join(to_list(flags))
         cmd = cmd.strip()
 
-        return self._connection.send_command(cmd, use_cache=True)
+        return self.send_command(cmd)
 
     def edit_config(
         self,
@@ -165,7 +165,7 @@ class Cliconf(CliconfBase):
             if not isinstance(line, Mapping):
                 line = {"command": line}
             cmd = line["command"]
-            results.append(self._connection.send_command(**line))
+            results.append(self.send_command(**line))
             requests.append(cmd)
 
         # Before any commit happend, we can get a real configuration
@@ -258,14 +258,13 @@ class Cliconf(CliconfBase):
             raise ValueError(
                 "'output' value %s is not supported for get" % output
             )
-        return self._connection.send_command(
+        return self.send_command(
             command=command,
             prompt=prompt,
             answer=answer,
             sendonly=sendonly,
             newline=newline,
             check_all=check_all,
-            use_cache=True,
         )
 
     def commit(self, comment=None, label=None, replace=None):
@@ -293,7 +292,7 @@ class Cliconf(CliconfBase):
             cmd_obj["prompt"] = "(C|c)onfirm"
             cmd_obj["answer"] = "y"
 
-        self._connection.send_command(**cmd_obj)
+        self.send_command(**cmd_obj)
 
     def run_commands(self, commands=None, check_rc=True):
         if commands is None:
@@ -310,11 +309,8 @@ class Cliconf(CliconfBase):
                     % output
                 )
 
-            if not cmd.get("prompt"):
-                cmd["use_cache"] = True
-
             try:
-                out = self._connection.send_command(**cmd)
+                out = self.send_command(**cmd)
             except AnsibleConnectionFailure as e:
                 if check_rc:
                     raise
@@ -338,7 +334,7 @@ class Cliconf(CliconfBase):
         return responses
 
     def discard_changes(self):
-        self._connection.send_command("abort")
+        self.send_command("abort")
 
     def get_device_operations(self):
         return {

--- a/plugins/cliconf/iosxr.py
+++ b/plugins/cliconf/iosxr.py
@@ -35,7 +35,7 @@ options:
       to the target device.
     - When `ansible_network_single_user_mode` is enabled, if a command sent
       to the device is present in this list, the existing cache is invalidated.
-    version_added: 1.2.0
+    version_added: 2.0.0
     type: list
     default: []
     vars:

--- a/plugins/cliconf/iosxr.py
+++ b/plugins/cliconf/iosxr.py
@@ -39,7 +39,7 @@ options:
     type: list
     default: []
     vars:
-    - name: ansible_ios_config_commands
+    - name: ansible_iosxr_config_commands
 """
 
 import re

--- a/plugins/terminal/iosxr.py
+++ b/plugins/terminal/iosxr.py
@@ -45,6 +45,8 @@ class TerminalModule(TerminalBase):
         re.compile(br"Failed to commit", re.I),
     ]
 
+    terminal_config_prompt = re.compile(r"^.+\(config(-.*)?\)#$")
+
     def on_open_shell(self):
         try:
             for cmd in (

--- a/tests/integration/targets/iosxr_smoke/tasks/cli.yaml
+++ b/tests/integration/targets/iosxr_smoke/tasks/cli.yaml
@@ -24,3 +24,8 @@
     loop_var: test_case_to_run
   tags:
     - local
+
+- name: run test cases with single_user_mode (connection=network_cli)
+  include: "{{ role_path }}/tests/cli/caching.yaml ansible_connection=network_cli ansible_network_single_user_mode=True ansible_connection=network_cli connection={{ cli }}"
+  tags:
+    - network_cli

--- a/tests/integration/targets/iosxr_smoke/tests/cli/caching.yaml
+++ b/tests/integration/targets/iosxr_smoke/tests/cli/caching.yaml
@@ -1,0 +1,114 @@
+---
+- block:
+  - debug: msg="START connection={{ ansible_connection }} cli/caching.yaml"
+
+  - name: Remove interfaces from config before actual testing
+    ignore_errors: true
+    cisco.iosxr.iosxr_config: &rem
+      lines:
+        - no interface GigabitEthernet 0/0/0/0
+        - no interface GigabitEthernet 0/0/0/1
+        - no interface GigabitEthernet 0/0/0/2
+        - no interface GigabitEthernet 0/0/0/4
+
+  - name: Merge base interfaces configuration
+    register: result
+    cisco.iosxr.iosxr_interfaces: &merged
+      config:
+        - name: GigabitEthernet0/0/0/0
+          description: Configured by Ansible
+          mtu: 110
+          enabled: true
+          duplex: half
+
+        - name: GigabitEthernet0/0/0/1
+          description: Configured by Ansible
+          mtu: 2800
+          speed: 100
+          duplex: full
+      state: merged
+
+  - assert:
+      that:
+        commands:
+          - '"interface GigabitEthernet0/0/0/0" in result.commands'
+          - '"description Configured and Merged by Ansible-Network" in result.commands'
+          - '"mtu 110" in result.commands'
+          - '"duplex half" in result.commands'
+          - '"interface GigabitEthernet0/0/0/1" in result.commands'
+          - '"description Configured and Merged by Ansible-Network" in result.commands'
+          - '"mtu 2800" in result.commands'
+          - '"speed 100" in result.commands'
+          - '"duplex full" in result.commands'
+          - result.commands|length == 9
+
+  - name: Merge base interfaces configuration (IDEMPOTENT)
+    register: result
+    cisco.iosxr.iosxr_interfaces: *merged
+
+  - assert:
+      that:
+        - result.changed == False
+
+  - name: Merge L2 interfaces configuration
+    register: result
+    cisco.iosxr.iosxr_l2_interfaces: &mergedl2
+      config:
+        - name: GigabitEthernet0/0/0/1
+          native_vlan: 10
+          l2transport: true
+          l2protocol:
+            - pvst: tunnel
+            - cdp: forward
+          propagate: true
+
+        - name: GigabitEthernet0/0/0/4
+          native_vlan: 40
+      state: merged
+
+  - assert:
+      that:
+        - '"interface GigabitEthernet0/0/0/1" in result.commands'
+        - '"dot1q native vlan 10" in result.commands'
+        - '"l2transport l2protocol pvst tunnel" in result.commands'
+        - '"l2transport l2protocol cdp forward" in result.commands'
+        - '"l2transport propagate remote-status" in result.commands'
+        - '"interface GigabitEthernet0/0/0/4" in result.commands'
+        - '"dot1q native vlan 40" in result.commands'
+        - result.commands|length == 7
+
+  - name: Merge L2 interfaces configuration (IDEMPOTENT)
+    register: result
+    cisco.iosxr.iosxr_l2_interfaces: *mergedl2
+
+  - assert:
+      that:
+        - result.changed == False
+
+  - name: Merge L3 interfaces configuration
+    register: result
+    cisco.iosxr.iosxr_l3_interfaces: &mergedl3
+      config:
+        - name: GigabitEthernet0/0/0/2
+          ipv4:
+            - address: 198.51.100.1/24
+      state: merged
+
+  - assert:
+      that:
+        - '"interface GigabitEthernet0/0/0/2" in result.commands'
+        - '"ipv4 address 198.51.100.1 255.255.255.0" in result.commands'
+        - result.commands|length == 2
+
+  - name: Merge L3 interfaces configuration (IDEMPOTENT)
+    register: result
+    cisco.iosxr.iosxr_l3_interfaces: *mergedl3
+
+  - assert:
+      that:
+        - result.changed == False
+
+  always:
+    - name: cleanup
+      cisco.iosxr.iosxr_config: *rem
+  when: ansible_connection == "network_cli" and ansible_network_single_user_mode|d(False)

--- a/tests/integration/targets/iosxr_smoke/tests/cli/caching.yaml
+++ b/tests/integration/targets/iosxr_smoke/tests/cli/caching.yaml
@@ -32,11 +32,11 @@
       that:
         commands:
           - '"interface GigabitEthernet0/0/0/0" in result.commands'
-          - '"description Configured and Merged by Ansible-Network" in result.commands'
+          - '"description Configured by Ansible" in result.commands'
           - '"mtu 110" in result.commands'
           - '"duplex half" in result.commands'
           - '"interface GigabitEthernet0/0/0/1" in result.commands'
-          - '"description Configured and Merged by Ansible-Network" in result.commands'
+          - '"description Configured by Ansible" in result.commands'
           - '"mtu 2800" in result.commands'
           - '"speed 100" in result.commands'
           - '"duplex full" in result.commands'

--- a/tests/integration/targets/iosxr_smoke/tests/cli/caching.yaml
+++ b/tests/integration/targets/iosxr_smoke/tests/cli/caching.yaml
@@ -6,41 +6,43 @@
     ignore_errors: true
     cisco.iosxr.iosxr_config: &rem
       lines:
-        - no interface GigabitEthernet 0/0/0/0
         - no interface GigabitEthernet 0/0/0/1
         - no interface GigabitEthernet 0/0/0/2
         - no interface GigabitEthernet 0/0/0/4
+      match: none
 
   - name: Merge base interfaces configuration
     register: result
     cisco.iosxr.iosxr_interfaces: &merged
       config:
-        - name: GigabitEthernet0/0/0/0
+        - name: GigabitEthernet0/0/0/1
           description: Configured by Ansible
           mtu: 110
           enabled: true
           duplex: half
 
-        - name: GigabitEthernet0/0/0/1
+        - name: GigabitEthernet0/0/0/2
           description: Configured by Ansible
           mtu: 2800
           speed: 100
+          enabled: true
           duplex: full
       state: merged
 
   - assert:
       that:
-        commands:
-          - '"interface GigabitEthernet0/0/0/0" in result.commands'
-          - '"description Configured by Ansible" in result.commands'
-          - '"mtu 110" in result.commands'
-          - '"duplex half" in result.commands'
-          - '"interface GigabitEthernet0/0/0/1" in result.commands'
-          - '"description Configured by Ansible" in result.commands'
-          - '"mtu 2800" in result.commands'
-          - '"speed 100" in result.commands'
-          - '"duplex full" in result.commands'
-          - result.commands|length == 9
+        - '"interface GigabitEthernet0/0/0/1" in result.commands'
+        - '"description Configured by Ansible" in result.commands'
+        - '"mtu 110" in result.commands'
+        - '"duplex half" in result.commands'
+        - '"no shutdown" in result.commands'
+        - '"interface GigabitEthernet0/0/0/2" in result.commands'
+        - '"description Configured by Ansible" in result.commands'
+        - '"mtu 2800" in result.commands'
+        - '"speed 100" in result.commands'
+        - '"duplex full" in result.commands'
+        - '"no shutdown" in result.commands'
+        - result.commands|length == 11
 
   - name: Merge base interfaces configuration (IDEMPOTENT)
     register: result

--- a/tests/integration/targets/iosxr_smoke/tests/cli/caching.yaml
+++ b/tests/integration/targets/iosxr_smoke/tests/cli/caching.yaml
@@ -11,6 +11,21 @@
         - no interface GigabitEthernet 0/0/0/4
       match: none
 
+  # We need to do this because of a bug in iosxr_interfaces module
+  # https://github.com/ansible-collections/cisco.iosxr/issues/106
+  - name: Add back interfaces to config before actual testing
+    ignore_errors: true
+    cisco.iosxr.iosxr_config:
+      lines: shutdown
+      parents: "interface GigabitEthernet {{ intf }}"
+      match: none
+    with_items:
+      - "0/0/0/1"
+      - "0/0/0/2"
+      - "0/0/0/4"
+    loop_control:
+      loop_var: intf
+
   - name: Merge base interfaces configuration
     register: result
     cisco.iosxr.iosxr_interfaces: &merged


### PR DESCRIPTION
##### SUMMARY
- Targets https://github.com/ansible-collections/ansible.netcommon/issues/73
- Add support for `ansible_single_user_mode` option added in network_cli.
- Re-use device_info dictionary for every session.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cliconf/iosxr.py
terminal/iosxr.py