### PR TITLE
IOSXR: Fix to accurately report configuration failure during pseudo-atomic operation 

### DIFF
--- a/changelogs/fragments/fix_iosxr_663_psudoatomic_failure.yaml
+++ b/changelogs/fragments/fix_iosxr_663_psudoatomic_failure.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix to accurately report configuration failure during pseudo-atomic operation fior iosxr-6.6.3 (https://github.com/ansible-collections/cisco.iosxr/issues/92).

--- a/plugins/terminal/iosxr.py
+++ b/plugins/terminal/iosxr.py
@@ -43,6 +43,7 @@ class TerminalModule(TerminalBase):
         re.compile(br"[^\r\n]+ not found", re.I),
         re.compile(br"'[^']' +returned error code: ?\d+"),
         re.compile(br"Failed to commit", re.I),
+        re.compile(br"show configuration failed \[inheritance\]", re.I),
     ]
 
     def on_open_shell(self):

--- a/tests/integration/targets/iosxr_config/tests/cli/comment.yaml
+++ b/tests/integration/targets/iosxr_config/tests/cli/comment.yaml
@@ -33,4 +33,28 @@
       - result.changed == false
       - result.updates is not defined
 
+- name: Assert accurately report configuration failure during pseudo-atomic operation
+  register: result
+  cisco.iosxr.iosxr_config:
+    lines:
+      - router bgp 65111
+      - neighbor 10.1.1.1
+      - update-source Loopback0
+
+- assert:
+    that:
+      - result.changed == false
+      - result.failure == true
+
+- name: Run show configuration failed
+  register: result
+  cisco.iosxr.iosxr_config:
+    lines:
+      - show configuration failed
+
+- assert:
+    that:
+      - result.changed == false
+      - result.failure == false
+
 - debug: msg="END cli/comment.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
Signed-off-by: Rohit Thakur <rohitthakur2590@outlook.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
resolve: https://github.com/ansible-collections/cisco.iosxr/issues/92
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/terminal/iosxr.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
