### PR TITLE
Move warning message for ios_config module

### DIFF
--- a/changelogs/fragments/config_module_warning_msg.yaml
+++ b/changelogs/fragments/config_module_warning_msg.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Move iosxr_config idempotent warning message with the task response under `warnings` key
+    if `changed` is `True`

--- a/plugins/modules/iosxr_config.py
+++ b/plugins/modules/iosxr_config.py
@@ -382,14 +382,6 @@ def run(module, result):
             commands = config_diff.split("\n")
 
         if any((module.params["lines"], module.params["src"])):
-            msg = (
-                "To ensure idempotency and correct diff the input configuration lines should be"
-                " similar to how they appear if present in the running configuration on device"
-            )
-            if module.params["src"]:
-                msg += " including the indentation"
-            module.warn(msg)
-
             if module.params["before"]:
                 commands[:0] = module.params["before"]
 
@@ -472,6 +464,21 @@ def main():
 
     if any((module.params["src"], module.params["lines"])):
         run(module, result)
+
+    if result.get("changed") and any(
+        (module.params["src"], module.params["lines"])
+    ):
+        msg = (
+            "To ensure idempotency and correct diff the input configuration lines should be"
+            " similar to how they appear if present in"
+            " the running configuration on device"
+        )
+        if module.params["src"]:
+            msg += " including the indentation"
+        if "warnings" in result:
+            result["warnings"].append(msg)
+        else:
+            result["warnings"] = msg
 
     module.exit_json(**result)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  Currently the warning message for diff is thrown
   for every module run.
*  Based on discussion here https://github.com/ansible/network/discussions/48
   a better way of logging the message is through verbose
   logs but verbose logging has a known issue https://github.com/ansible-collections/ansible.netcommon/issues/224
*  Hence moving the message under `warnings` key within the task
   response if `changed=True`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
iosxr_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
