### PR TITLE
Fix:iosxr_interfaces does not work on interfaces that are not in running-config

### DIFF
--- a/changelogs/fragments/114_iosxr_interfaces_merged_state_fix.yaml
+++ b/changelogs/fragments/114_iosxr_interfaces_merged_state_fix.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Add fix for interfaces which are not in running config should get merged when state is merged.
+    (https://github.com/ansible-collections/cisco.iosxr/issues/106)

--- a/plugins/module_utils/network/iosxr/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/iosxr/config/interfaces/interfaces.py
@@ -167,7 +167,6 @@ class Interfaces(ConfigBase):
         commands = []
 
         for interface in want:
-            interface["name"] = normalize_interface(interface["name"])
             for each in have:
                 if (
                     each["name"] == interface["name"]
@@ -195,7 +194,6 @@ class Interfaces(ConfigBase):
 
         for each in have:
             for interface in want:
-                interface["name"] = normalize_interface(interface["name"])
                 if (
                     each["name"] == interface["name"]
                     or interface["name"] in each["name"]
@@ -225,7 +223,6 @@ class Interfaces(ConfigBase):
         commands = []
         flag = 0
         for interface in want:
-            interface["name"] = normalize_interface(interface["name"])
             if self.state == "rendered":
                 commands.extend(self._set_config(interface, dict()))
             else:
@@ -253,7 +250,6 @@ class Interfaces(ConfigBase):
 
         if want:
             for interface in want:
-                interface["name"] = normalize_interface(interface["name"])
                 for each in have:
                     if (
                         each["name"] == interface["name"]
@@ -274,6 +270,7 @@ class Interfaces(ConfigBase):
     def _set_config(self, want, have):
         # Set the interface config based on the want and have config
         commands = []
+        want["name"] = normalize_interface(want["name"])
         interface = "interface " + want["name"]
         # Get the diff b/w want and have
         want_dict = dict_to_set(want)

--- a/plugins/module_utils/network/iosxr/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/iosxr/config/interfaces/interfaces.py
@@ -220,7 +220,7 @@ class Interfaces(ConfigBase):
                   the current configuration
         """
         commands = []
-
+        flag = 0
         for interface in want:
             if self.state == "rendered":
                 commands.extend(self._set_config(interface, dict()))
@@ -230,10 +230,12 @@ class Interfaces(ConfigBase):
                         each["name"] == interface["name"]
                         or interface["name"] in each["name"]
                     ):
+                        flag = 1
                         break
+                if flag == 1:
+                    commands.extend(self._set_config(interface, each))
                 else:
-                    continue
-                commands.extend(self._set_config(interface, each))
+                    commands.extend(self._set_config(interface, dict()))
 
         return commands
 

--- a/plugins/module_utils/network/iosxr/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/iosxr/config/interfaces/interfaces.py
@@ -26,6 +26,7 @@ from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.facts.fa
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import (
     get_interface_type,
     dict_to_set,
+    normalize_interface,
 )
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import (
     remove_command_from_config_list,
@@ -166,6 +167,7 @@ class Interfaces(ConfigBase):
         commands = []
 
         for interface in want:
+            interface["name"] = normalize_interface(interface["name"])
             for each in have:
                 if (
                     each["name"] == interface["name"]
@@ -193,6 +195,7 @@ class Interfaces(ConfigBase):
 
         for each in have:
             for interface in want:
+                interface["name"] = normalize_interface(interface["name"])
                 if (
                     each["name"] == interface["name"]
                     or interface["name"] in each["name"]
@@ -222,6 +225,7 @@ class Interfaces(ConfigBase):
         commands = []
         flag = 0
         for interface in want:
+            interface["name"] = normalize_interface(interface["name"])
             if self.state == "rendered":
                 commands.extend(self._set_config(interface, dict()))
             else:
@@ -249,6 +253,7 @@ class Interfaces(ConfigBase):
 
         if want:
             for interface in want:
+                interface["name"] = normalize_interface(interface["name"])
                 for each in have:
                     if (
                         each["name"] == interface["name"]
@@ -270,7 +275,6 @@ class Interfaces(ConfigBase):
         # Set the interface config based on the want and have config
         commands = []
         interface = "interface " + want["name"]
-
         # Get the diff b/w want and have
         want_dict = dict_to_set(want)
         have_dict = dict_to_set(have)

--- a/tests/integration/targets/iosxr_interfaces/tests/cli/merged.yaml
+++ b/tests/integration/targets/iosxr_interfaces/tests/cli/merged.yaml
@@ -57,3 +57,59 @@
   always:
 
     - include_tasks: _remove_config.yaml
+
+- debug:
+    msg: START Merged interfaces configuration which are not in running config with iosxr_interfaces module on connection={{
+      ansible_connection }}
+
+- include_tasks: _remove_config.yaml
+- block:
+
+    - name: Merge provided configuration with device configuration
+      register: result
+      cisco.iosxr.iosxr_interfaces: &id002
+        config:
+
+          - name: GigabitEthernet0/0/0/2
+            description: Configured and Merged by Ansible-Network
+            mtu: 110
+            enabled: true
+            duplex: half
+
+          - name: GigabitEthernet0/0/0/3
+            description: Configured and Merged by Ansible-Network
+            mtu: 2800
+            enabled: false
+            speed: 100
+            duplex: full
+        state: merged
+
+    - name: Assert that correct set of commands were generated
+      assert:
+        that:
+          - "{{ merged['preconfigure']['commands'] | symmetric_difference(result['commands']) |\
+            \ length == 0 }}"
+
+    - name: Assert that before dicts are correctly generated
+      assert:
+        that:
+          - "{{ merged['preconfigure']['before'] | symmetric_difference(result['before']) | length\
+          \ == 0 }}"
+
+    - name: Assert that after dict is correctly generated
+      assert:
+        that:
+          - "{{ merged['preconfigure']['after'] | symmetric_difference(result['after']) | length\
+            \ == 0 }}"
+
+    - name: Merge provided configuration with device configuration (IDEMPOTENT)
+      register: result
+      cisco.iosxr.iosxr_interfaces: *id002
+
+    - name: Assert that the previous task was idempotent
+      assert:
+        that:
+          - result['changed'] == false
+  always:
+
+    - include_tasks: _remove_config.yaml

--- a/tests/integration/targets/iosxr_interfaces/vars/main.yaml
+++ b/tests/integration/targets/iosxr_interfaces/vars/main.yaml
@@ -43,6 +43,41 @@ merged:
       mtu: 2800
       name: GigabitEthernet0/0/0/1
       speed: 100
+  preconfigure:
+    before:
+      - enabled: true
+        name: Loopback888
+      - enabled: true
+        name: Loopback999
+    commands:
+      - interface GigabitEthernet0/0/0/2
+      - description Configured and Merged by Ansible-Network
+      - mtu 110
+      - duplex half
+      - no shutdown
+      - interface GigabitEthernet0/0/0/3
+      - description Configured and Merged by Ansible-Network
+      - mtu 2800
+      - speed 100
+      - duplex full
+      - shutdown
+    after:
+      - enabled: true
+        name: Loopback888
+      - enabled: true
+        name: Loopback999
+      - description: Configured and Merged by Ansible-Network
+        duplex: half
+        enabled: true
+        mtu: 110
+        name: GigabitEthernet0/0/0/2
+      - description: Configured and Merged by Ansible-Network
+        duplex: full
+        enabled: false
+        mtu: 2800
+        speed: 100
+        name: GigabitEthernet0/0/0/3
+
 parsed:
   after:
     - description: test for ansible


### PR DESCRIPTION
update logic for state merge when interfaces are not from running-config
fixes: https://github.com/ansible-collections/cisco.iosxr/issues/106

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
iosxr_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
