### PR TITLE
Bump ansible.netcommon requirement to >=2.0.1

### DIFF
--- a/changelogs/fragments/bump_netcommon.yaml
+++ b/changelogs/fragments/bump_netcommon.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - For versions >=2.0.1, this collection requires ansible.netcommon >=2.0.1.
+  - Re-releasing this collection with ansible.netcommon dependency requirements updated.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 authors:
   - Ansible Network Community (ansible-network)
 dependencies:
-  "ansible.netcommon": ">=2.0.0"
+  "ansible.netcommon": ">=2.0.1"
 license_file: LICENSE
 name: iosxr
 namespace: cisco


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- The changes introduced in #123 are dependent on ansible.netcommon:2.0.1. This was not updated in galaxy.yml causing affected modules to fail in cisco.iosxr:2.0.1 if the netcommon installed is <2.0.1.
- This patch bumps the requirement in galaxy.yml.
- We will need a v2.0.2 release for this collection.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
galaxy.yml

