### PR TITLE
Add python38-lxml to bindep.txt

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -5,5 +5,4 @@ gcc-c++ [doc test platform:rpm]
 python3-devel [test platform:rpm]
 python3 [test platform:rpm]
 
-libxml2-dev [platform:dpkg]
-libxslt-dev [platform:dpkg]
+python38-lxml [platform:centos-8 platform:rhel-8]


### PR DESCRIPTION
This is used by execution environments.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>