### PR TITLE
Fix issue of commit operation which was not failing for invalid inp…

### DIFF
--- a/changelogs/fragments/bugfix-138-handle-errror-when-commit-operation.yaml
+++ b/changelogs/fragments/bugfix-138-handle-errror-when-commit-operation.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fix issue of commit operation which was not failing for invalid inputs.
+  - Add warning when comment is not supported by IOSXR.

--- a/plugins/cliconf/iosxr.py
+++ b/plugins/cliconf/iosxr.py
@@ -185,8 +185,18 @@ class Cliconf(CliconfBase):
                     "Invalid input detected" in error_msg
                     and "comment" in error_msg
                 ):
+                    msg = (
+                            "value of comment option '%s' is ignored as it in not supported by IOSXR"
+                            % comment
+                    )
+                    self._connection.queue_message(
+                        "warning",
+                        msg,
+                    )
                     comment = None
                     self.commit(comment=comment, label=label, replace=replace)
+                else:
+                    raise ConnectionError(error_msg)
 
         else:
             self.discard_changes()

--- a/plugins/cliconf/iosxr.py
+++ b/plugins/cliconf/iosxr.py
@@ -186,13 +186,10 @@ class Cliconf(CliconfBase):
                     and "comment" in error_msg
                 ):
                     msg = (
-                            "value of comment option '%s' is ignored as it in not supported by IOSXR"
-                            % comment
+                        "value of comment option '%s' is ignored as it in not supported by IOSXR"
+                        % comment
                     )
-                    self._connection.queue_message(
-                        "warning",
-                        msg,
-                    )
+                    self._connection.queue_message("warning", msg)
                     comment = None
                     self.commit(comment=comment, label=label, replace=replace)
                 else:


### PR DESCRIPTION
- Fix issue of commit operation which was not failing for invalid inputs.
- Add warning when comment is not supported by IOSXR.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR fixes one scenario which was not handled in https://github.com/ansible-collections/cisco.iosxr/pull/135
fixes: https://github.com/ansible-collections/cisco.iosxr/issues/138
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
