### PR TITLE
Don't rely on safe_eval being able to do math/concat

### DIFF
--- a/changelogs/fragments/160-safe-eval-no-concat.yml
+++ b/changelogs/fragments/160-safe-eval-no-concat.yml
@@ -1,0 +1,3 @@
+trivial:
+- Don't rely on ``safe_eval`` being able to do math/concat
+  (https://github.com/ansible-collections/cisco.iosxr/pull/160)

--- a/changelogs/fragments/160-safe-eval-no-concat.yml
+++ b/changelogs/fragments/160-safe-eval-no-concat.yml
@@ -1,3 +1,4 @@
+---
 trivial:
-- Don't rely on ``safe_eval`` being able to do math/concat
-  (https://github.com/ansible-collections/cisco.iosxr/pull/160)
+  - Don't rely on ``safe_eval`` being able to do math/concat
+    (https://github.com/ansible-collections/cisco.iosxr/pull/160)

--- a/tests/integration/targets/iosxr_bgp_address_family/tasks/cli.yaml
+++ b/tests/integration/targets/iosxr_bgp_address_family/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/iosxr_bgp_global/tasks/cli.yaml
+++ b/tests/integration/targets/iosxr_bgp_global/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/iosxr_bgp_neighbor_address_family/tasks/cli.yaml
+++ b/tests/integration/targets/iosxr_bgp_neighbor_address_family/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/iosxr_user/tasks/cli.yaml
+++ b/tests/integration/targets/iosxr_user/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ common_test_cases.files }} + {{ test_cases.files }}'
+      files: '{{ common_test_cases.files + test_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/iosxr_user/tasks/netconf.yaml
+++ b/tests/integration/targets/iosxr_user/tasks/netconf.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ common_test_cases.files }} + {{ test_cases.files }}'
+      files: '{{ common_test_cases.files + test_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"


### PR DESCRIPTION
##### SUMMARY
Don't rely on `safe_eval` being able to do math/concat. This functionality will be removed in ansible-core 2.12, and has never worked with jinja2 native which we are working toward making the default in 2.12.

See https://github.com/ansible/ansible/pull/75068

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/integration/targets/

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
