### PR TITLE
fix issue of local variable 'start_index' referenced before assignment with cisco.iosxr.iosxr_config

### DIFF
--- a/changelogs/fragments/191_bugfix.yml
+++ b/changelogs/fragments/191_bugfix.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - Fix issue in iosxr_config module.
+  - fix issue of local variable 'start_index' referenced before assignment with cisco.iosxr.iosxr_config.

--- a/changelogs/fragments/191_bugfix.yml
+++ b/changelogs/fragments/191_bugfix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix issue in iosxr_config module.

--- a/plugins/module_utils/network/iosxr/iosxr.py
+++ b/plugins/module_utils/network/iosxr/iosxr.py
@@ -633,13 +633,14 @@ def mask_config_blocks_from_diff(config, candidate, force_diff_prefix):
 
     for regex in CONFIG_BLOCKS_FORCED_IN_DIFF:
         block_index_start_end = []
+        start_index = None
         for index, line in enumerate(candidate_lines):
             startre = regex["start"].search(line)
             if startre and startre.group(0):
                 start_index = index
             else:
                 endre = regex["end"].search(line)
-                if endre and endre.group(0):
+                if endre and endre.group(0) and start_index:
                     end_index = index
                     new_block = True
                     for prev_start, prev_end in block_index_start_end:

--- a/tests/integration/targets/iosxr_config/tests/cli/extcommunity_set_config.yaml
+++ b/tests/integration/targets/iosxr_config/tests/cli/extcommunity_set_config.yaml
@@ -1,0 +1,27 @@
+---
+- debug: msg="START cli/extcommunity_set_config.yaml on connection={{ ansible_connection }}"
+
+- name: pre-setup cleanup
+  cisco.iosxr.iosxr_config:
+    commands:
+      - no extcommunity-set rt test_set
+
+- name: setup
+  register: result
+  cisco.iosxr.iosxr_config:
+    lines:
+      - 6667:1234
+      - end-set
+    parents: extcommunity-set rt test_set
+
+- assert:
+    that:
+      - result.changed == true
+
+- name: post-setup cleanup
+  cisco.iosxr.iosxr_config:
+    commands:
+      - no extcommunity-set rt test_set
+
+
+- debug: msg="END cli/ on connection={{ ansible_connection }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fixes: https://github.com/ansible-collections/cisco.iosxr/issues/191
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
