### PR TITLE
FIX:iosxr_acls pushes wrong commands when "show access-lists" output contains "(XX matches)" notes

### DIFF
--- a/changelogs/fragments/bugfix_acl_194.yaml
+++ b/changelogs/fragments/bugfix_acl_194.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "`iosxr_acls` - fix acl for parsing wrong command on ( num matches ) data"

--- a/plugins/module_utils/network/iosxr/facts/acls/acls.py
+++ b/plugins/module_utils/network/iosxr/facts/acls/acls.py
@@ -153,7 +153,11 @@ class AclsFacts(object):
         self.generated_spec = utils.generate_dict(facts_argument_spec)
 
     def get_device_data(self, connection):
-        return connection.get("show access-lists afi-all")
+        ipv4_data = connection.get("show running-config ipv4 access-list")
+        ipv6_data = connection.get("show running-config ipv6 access-list")
+        data = ipv4_data + '\n' + ipv6_data
+        data = data.replace("\n!", "")
+        return data
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """ Populate the facts for acls

--- a/plugins/module_utils/network/iosxr/facts/acls/acls.py
+++ b/plugins/module_utils/network/iosxr/facts/acls/acls.py
@@ -28,6 +28,7 @@ from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import (
     isipaddress,
 )
+import re
 
 PROTOCOL_OPTIONS = {
     "tcp": ("ack", "fin", "psh", "rst", "syn", "urg", "established"),
@@ -153,11 +154,7 @@ class AclsFacts(object):
         self.generated_spec = utils.generate_dict(facts_argument_spec)
 
     def get_device_data(self, connection):
-        ipv4_data = connection.get("show running-config ipv4 access-list")
-        ipv6_data = connection.get("show running-config ipv6 access-list")
-        data = ipv4_data + '\n' + ipv6_data
-        data = data.replace("\n!", "")
-        return data
+        return connection.get("show access-lists afi-all")
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """ Populate the facts for acls
@@ -179,6 +176,8 @@ class AclsFacts(object):
         if acl_lines:
             acl, acls = {}, []
             for line in acl_lines:
+                if "matches" in line:
+                    line = re.sub(r"\([^()]*\)", "", line)
                 if line.startswith("ip"):
                     if acl:
                         acls.append(acl)

--- a/tests/unit/modules/network/iosxr/test_iosxr_acls.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_acls.py
@@ -476,7 +476,23 @@ class TestIosxrAclsModule(TestIosxrModule):
             )
         )
         result = self.execute_module(changed=False)
-        parsed_list = [{'acls': [{'name': 'ACL_NAME', 'aces': [{'sequence': 5, 'grant': 'permit', 'protocol': 'ipv4', 'source': {'host': 'x.x.x.x'}, 'destination': {'any': True}}]}], 'afi': 'ipv4'}]
-        print(result)
+        parsed_list = [
+            {
+                "acls": [
+                    {
+                        "name": "ACL_NAME",
+                        "aces": [
+                            {
+                                "sequence": 5,
+                                "grant": "permit",
+                                "protocol": "ipv4",
+                                "source": {"host": "x.x.x.x"},
+                                "destination": {"any": True},
+                            }
+                        ],
+                    }
+                ],
+                "afi": "ipv4",
+            }
+        ]
         self.assertEqual(parsed_list, result["parsed"])
-

--- a/tests/unit/modules/network/iosxr/test_iosxr_acls.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_acls.py
@@ -467,3 +467,16 @@ class TestIosxrAclsModule(TestIosxrModule):
         )
         cmds = ["ipv4 access-list acl_1", "10 deny ip any any"]
         self.execute_module(changed=True, commands=cmds)
+
+    def test_iosxr_acls_parsed_matches(self):
+        set_module_args(
+            dict(
+                running_config="""ipv4 access-list ACL_NAME\n5 permit ipv4 host x.x.x.x any (409 matches)""",
+                state="parsed",
+            )
+        )
+        result = self.execute_module(changed=False)
+        parsed_list = [{'acls': [{'name': 'ACL_NAME', 'aces': [{'sequence': 5, 'grant': 'permit', 'protocol': 'ipv4', 'source': {'host': 'x.x.x.x'}, 'destination': {'any': True}}]}], 'afi': 'ipv4'}]
+        print(result)
+        self.assertEqual(parsed_list, result["parsed"])
+


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fixes: https://github.com/ansible-collections/cisco.iosxr/issues/194
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
