### PR TITLE
[facts] default value for gather_subset is changed to min instead of !config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This collection has been tested against Cisco IOSXR version 7.0.2.
 
 This collection has been tested against following Ansible versions: **>=2.9.10**.
 
+For collections that support Ansible 2.9, please ensure you update your `network_os` to use the 
+fully qualified collection name (for example, `cisco.ios.ios`). 
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.
 PEP440 is the schema used to describe the versions of Ansible.

--- a/changelogs/fragments/gather_subset_update.yml
+++ b/changelogs/fragments/gather_subset_update.yml
@@ -1,0 +1,3 @@
+---
+major_changes:
+  - "`facts` - default value for `gather_subset` is changed to min instead of !config."

--- a/docs/cisco.iosxr.iosxr_bgp_global_module.rst
+++ b/docs/cisco.iosxr.iosxr_bgp_global_module.rst
@@ -3359,7 +3359,7 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="6">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>neighbor</b>
+                    <b>neighbor_address</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
@@ -3370,7 +3370,7 @@ Parameters
                 </td>
                 <td>
                         <div>Neighbor router address.</div>
-                        <div style="font-size: small; color: darkgreen"><br/>aliases: neighbor_address</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: neighbor</div>
                 </td>
             </tr>
             <tr>
@@ -7628,7 +7628,7 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="5">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>neighbor</b>
+                    <b>neighbor_address</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
@@ -7639,7 +7639,7 @@ Parameters
                 </td>
                 <td>
                         <div>Neighbor router address.</div>
-                        <div style="font-size: small; color: darkgreen"><br/>aliases: neighbor_address</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: neighbor</div>
                 </td>
             </tr>
             <tr>

--- a/docs/cisco.iosxr.iosxr_cliconf.rst
+++ b/docs/cisco.iosxr.iosxr_cliconf.rst
@@ -80,6 +80,7 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>
                     </div>
                     <div style="font-style: italic; font-size: small; color: darkgreen">added in 2.0.0</div>
                 </td>

--- a/docs/cisco.iosxr.iosxr_facts_module.rst
+++ b/docs/cisco.iosxr.iosxr_facts_module.rst
@@ -79,7 +79,7 @@ Parameters
                     </div>
                 </td>
                 <td>
-                        <b>Default:</b><br/><div style="color: blue">"!config"</div>
+                        <b>Default:</b><br/><div style="color: blue">"min"</div>
                 </td>
                 <td>
                         <div>When supplied, this argument will restrict the facts collected to a given subset.  Possible values for this argument include all, hardware, config, and interfaces.  Can specify a list of values to include a larger subset.  Values can also be used with an initial <code>!</code> to specify that a specific subset should not be collected.</div>

--- a/docs/cisco.iosxr.iosxr_user_module.rst
+++ b/docs/cisco.iosxr.iosxr_user_module.rst
@@ -28,7 +28,6 @@ The below requirements are needed on the host that executes this module.
 - ncclient >= 0.5.3 when using netconf
 - lxml >= 4.1.1 when using netconf
 - base64 when using *public_key_contents* or *public_key*
-- paramiko when using *public_key_contents* or *public_key*
 
 
 Parameters

--- a/plugins/module_utils/network/iosxr/argspec/facts/facts.py
+++ b/plugins/module_utils/network/iosxr/argspec/facts/facts.py
@@ -19,9 +19,7 @@ class FactsArgs(object):  # pylint: disable=R0903
         pass
 
     argument_spec = {
-        "gather_subset": dict(
-            default=["!config"], type="list", elements="str"
-        ),
+        "gather_subset": dict(default=["min"], type="list", elements="str"),
         "gather_network_resources": dict(type="list", elements="str"),
         "available_network_resources": {"type": "bool", "default": False},
     }

--- a/plugins/modules/iosxr_facts.py
+++ b/plugins/modules/iosxr_facts.py
@@ -36,7 +36,7 @@ options:
       specify a list of values to include a larger subset.  Values can also be used
       with an initial C(!) to specify that a specific subset should not be collected.
     required: false
-    default: '!config'
+    default: 'min'
     type: list
     elements: str
   gather_network_resources:

--- a/tests/integration/targets/iosxr_facts/tests/cli/default_facts.yaml
+++ b/tests/integration/targets/iosxr_facts/tests/cli/default_facts.yaml
@@ -9,13 +9,15 @@
 - assert:
     that:
       - result.changed == false
-      - "'hardware' in result.ansible_facts.ansible_net_gather_subset"
       - "'default' in result.ansible_facts.ansible_net_gather_subset"
-      - "'interfaces' in result.ansible_facts.ansible_net_gather_subset"
-      - result.ansible_facts.ansible_net_filesystems is defined
       - "'config' not in result.ansible_facts.ansible_net_gather_subset"
-      - result.ansible_facts.ansible_net_filesystems is defined
-      - result.ansible_facts.ansible_net_interfaces | length > 1
-      - result.ansible_facts.ansible_net_config is not defined
+      - result.ansible_facts.ansible_net_hostname is defined
+      - result.ansible_facts.ansible_net_image is defined
+      - result.ansible_facts.ansible_net_model is defined
+      - result.ansible_facts.ansible_net_python_version is defined
+      - result.ansible_facts.ansible_net_serialnum is defined
+      - result.ansible_facts.ansible_net_system is defined
+      - result.ansible_facts.ansible_net_version is defined
+      - result.ansible_facts.ansible_network_resources == {}
 
 - debug: msg="END cli/default.yaml on connection={{ ansible_connection }}"

--- a/tests/unit/modules/network/iosxr/test_iosxr_facts.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_facts.py
@@ -93,19 +93,18 @@ class TestIosxrFacts(TestIosxrModule):
         set_module_args(dict())
         result = self.execute_module()
         ansible_facts = result["ansible_facts"]
-        self.assertIn("hardware", ansible_facts["ansible_net_gather_subset"])
-        self.assertIn("default", ansible_facts["ansible_net_gather_subset"])
-        self.assertIn("interfaces", ansible_facts["ansible_net_gather_subset"])
-        self.assertEqual("iosxr01", ansible_facts["ansible_net_hostname"])
-        self.assertEqual(
-            ["disk0:", "flash0:"], ansible_facts["ansible_net_filesystems"]
-        )
-        self.assertIn(
-            "GigabitEthernet0/0/0/0",
-            ansible_facts["ansible_net_interfaces"].keys(),
-        )
-        self.assertEqual("3095", ansible_facts["ansible_net_memtotal_mb"])
-        self.assertEqual("1499", ansible_facts["ansible_net_memfree_mb"])
+        op = {
+            "ansible_network_resources": {},
+            "ansible_net_gather_network_resources": [],
+            "ansible_net_gather_subset": ["default"],
+            "ansible_net_system": "iosxr",
+            "ansible_net_image": "bootflash:disk0/xrvr-os-mbi-6.1.3/mbixrvr-rp.vm",
+            "ansible_net_version": "6.1.3[Default]",
+            "ansible_net_hostname": "iosxr01",
+            "ansible_net_api": "cliconf",
+            "ansible_net_python_version": "3.8.13",
+        }
+        self.assertEqual(op, ansible_facts)
 
     def test_iosxr_facts_gather_subset_config(self):
         set_module_args({"gather_subset": "config"})

--- a/tests/unit/modules/network/iosxr/test_iosxr_facts.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_facts.py
@@ -93,18 +93,21 @@ class TestIosxrFacts(TestIosxrModule):
         set_module_args(dict())
         result = self.execute_module()
         ansible_facts = result["ansible_facts"]
-        op = {
-            "ansible_network_resources": {},
-            "ansible_net_gather_network_resources": [],
-            "ansible_net_gather_subset": ["default"],
-            "ansible_net_system": "iosxr",
-            "ansible_net_image": "bootflash:disk0/xrvr-os-mbi-6.1.3/mbixrvr-rp.vm",
-            "ansible_net_version": "6.1.3[Default]",
-            "ansible_net_hostname": "iosxr01",
-            "ansible_net_api": "cliconf",
-            "ansible_net_python_version": "3.8.13",
-        }
-        self.assertEqual(op, ansible_facts)
+        self.assertIn("default", ansible_facts["ansible_net_gather_subset"][0])
+        self.assertEqual(
+            [], ansible_facts["ansible_net_gather_network_resources"]
+        )
+        self.assertEqual("iosxr", ansible_facts["ansible_net_system"])
+        self.assertEqual(
+            True, True if ansible_facts.get("ansible_net_version") else False
+        )
+        self.assertEqual(
+            True,
+            True if ansible_facts.get("ansible_net_python_version") else False,
+        )
+        self.assertEqual(
+            True, True if ansible_facts.get("ansible_net_api") else False
+        )
 
     def test_iosxr_facts_gather_subset_config(self):
         set_module_args({"gather_subset": "config"})


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
default value for `gather_subset` is changed to `min` instead of `!config` 
Depends-On: https://github.com/ansible/network-ee/pull/155
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
