### PR TITLE
Fix commit confirm for IOSXR

### DIFF
--- a/changelogs/fragments/confirm_commit.yml
+++ b/changelogs/fragments/confirm_commit.yml
@@ -1,4 +1,0 @@
----
-minor_changes:
-  - Update commit_confirmed to be able to use labels and other commit options.
-...

--- a/changelogs/fragments/confirm_commit_update.yml
+++ b/changelogs/fragments/confirm_commit_update.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Update commit_confirmed to add proper commands on supported IOXR versions.

--- a/plugins/cliconf/iosxr.py
+++ b/plugins/cliconf/iosxr.py
@@ -352,10 +352,10 @@ class Cliconf(CliconfBase):
         cmt_cnf_cmd = ""
         if self.get_option("commit_confirmed"):
             cmt_cnf_cmd = "commit confirmed"
-        if self.get_option("commit_confirmed_timeout"):
-            cmt_cnf_cmd = "commit confirmed {0}".format(
-                self.get_option("commit_confirmed_timeout")
-            )
+            if self.get_option("commit_confirmed_timeout"):
+                cmt_cnf_cmd += " {0}".format(
+                    self.get_option("commit_confirmed_timeout")
+                )
 
         if cmt_cnf_cmd:
             self.send_command(cmt_cnf_cmd)

--- a/plugins/cliconf/iosxr.py
+++ b/plugins/cliconf/iosxr.py
@@ -324,7 +324,6 @@ class Cliconf(CliconfBase):
             label (string, optional): Defaults to None.
             replace (string, optional): Defaults to None.
         """
-        cmd_obj = {}
 
         if replace:
             self.send_command(
@@ -350,21 +349,16 @@ class Cliconf(CliconfBase):
                     "commit show-error", prompt="yes/no", answer="yes"
                 )
 
+        cmt_cnf_cmd = ""
         if self.get_option("commit_confirmed"):
-            self.send_command("commit confirmed")
+            cmt_cnf_cmd = "commit confirmed"
         if self.get_option("commit_confirmed_timeout"):
-            self.send_command(
-                "commit confirmed{0}".format(
-                    self.get_option("commit_confirmed_timeout")
-                )
+            cmt_cnf_cmd = "commit confirmed {0}".format(
+                self.get_option("commit_confirmed_timeout")
             )
 
-        if any(
-            [
-                self.get_option("commit_confirmed"),
-                self.get_option("commit_confirmed_timeout"),
-            ]
-        ):
+        if cmt_cnf_cmd:
+            self.send_command(cmt_cnf_cmd)
             self.send_command("commit")
 
     def run_commands(self, commands=None, check_rc=True):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
1. Fix commit to confirm functionality for IOS XR
2. Reverts changes that consider iosxr_configs commit label & comment with cliconf's commit confirmed label and comment.
(needs to be implemented in cliconf separately).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cliconf
config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
