### PR TITLE
[iosxr_ping] Parse unsuccessful ping correctly

### DIFF
--- a/changelogs/fragments/re_order_regex_ping.yml
+++ b/changelogs/fragments/re_order_regex_ping.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "`iosxr_ping` - Fix regex to parse ping failure correctly."

--- a/plugins/module_utils/network/iosxr/rm_templates/ping.py
+++ b/plugins/module_utils/network/iosxr/rm_templates/ping.py
@@ -35,7 +35,7 @@ class PingTemplate(NetworkTemplate):
                 ^Success\srate\sis
                 (\s(?P<pct>\d+))?
                 (\spercent\s\((?P<rx>\d+)/(?P<tx>\d+)\))?
-                ,\s+round-trip\smin/avg/max\s=
+                (,\s+round-trip\smin/avg/max\s=)?
                 (\s(?P<min>\d+)/(?P<avg>\d+)/(?P<max>\d+))?
                 (\s+\w+\s*$|.*\s*$)?
                 ''', re.VERBOSE,

--- a/tests/unit/modules/network/iosxr/test_iosxr_ping.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_ping.py
@@ -144,7 +144,7 @@ class TestIosxrPingModule(TestIosxrModule):
             Success rate is 0 percent (0/5)
             """,
         )
-        set_module_args(dict(count=2, dest="8.8.8.8", state="absent"))
+        set_module_args(dict(count=2, dest="192.0.2.1", state="absent"))
         result = self.execute_module(failed=False)
         print(result)
         mock_res = {

--- a/tests/unit/modules/network/iosxr/test_iosxr_ping.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_ping.py
@@ -135,6 +135,28 @@ class TestIosxrPingModule(TestIosxrModule):
         }
         self.assertEqual(result, mock_res)
 
+    def test_iosxr_ping_state_absent_pass(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            Type escape sequence to abort.
+            Sending 5, 100-byte ICMP Echos to 192.0.2.1, timeout is 2 seconds:
+            .....
+            Success rate is 0 percent (0/5)
+            """,
+        )
+        set_module_args(dict(count=2, dest="8.8.8.8", state="absent"))
+        result = self.execute_module(failed=False)
+        print(result)
+        mock_res = {
+            "commands": "ping ipv4 192.0.2.1 count 2",
+            "packet_loss": "100%",
+            "packets_rx": 0,
+            "packets_tx": 5,
+            "rtt": {},
+            "changed": False,
+        }
+        self.assertEqual(result, mock_res)
+
     def test_iosxr_ping_state_absent_present_fail(self):
         self.execute_show_command.return_value = dedent(
             """\


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Parse unsuccessful ping correctly
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
iosxr_ping
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
