### PR TITLE
[bgp_neighbor_address_family] add extra supported values to afi attribute

### DIFF
--- a/changelogs/fragments/bgp_af_fam_284.yaml
+++ b/changelogs/fragments/bgp_af_fam_284.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "iosxr_bgp_neighbor_address_family - add extra supported values to afi attribute."
+  - "iosxr_bgp_neighbor_address_family - add extra supported values l2vpn, link-state, vpnv4, vpnv6 to afi attribute."

--- a/changelogs/fragments/bgp_af_fam_284.yaml
+++ b/changelogs/fragments/bgp_af_fam_284.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "ios_bgp_neighbor_address_family - add extra supported values to afi attribute."
+  - "iosxr_bgp_neighbor_address_family - add extra supported values to afi attribute."

--- a/changelogs/fragments/bgp_af_fam_284.yaml
+++ b/changelogs/fragments/bgp_af_fam_284.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "ios_bgp_neighbor_address_family - add extra supported values to afi attribute."

--- a/docs/cisco.iosxr.iosxr_bgp_neighbor_address_family_module.rst
+++ b/docs/cisco.iosxr.iosxr_bgp_neighbor_address_family_module.rst
@@ -1864,10 +1864,6 @@ Parameters
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>
                                     <li>ipv4</li>
                                     <li>ipv6</li>
-                                    <li>l2vpn</li>
-                                    <li>link-state</li>
-                                    <li>vpnv4</li>
-                                    <li>vpnv6</li>
                         </ul>
                 </td>
                 <td>

--- a/docs/cisco.iosxr.iosxr_bgp_neighbor_address_family_module.rst
+++ b/docs/cisco.iosxr.iosxr_bgp_neighbor_address_family_module.rst
@@ -115,6 +115,10 @@ Parameters
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>
                                     <li>ipv4</li>
                                     <li>ipv6</li>
+                                    <li>l2vpn</li>
+                                    <li>link-state</li>
+                                    <li>vpnv4</li>
+                                    <li>vpnv6</li>
                         </ul>
                 </td>
                 <td>
@@ -1860,6 +1864,10 @@ Parameters
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>
                                     <li>ipv4</li>
                                     <li>ipv6</li>
+                                    <li>l2vpn</li>
+                                    <li>link-state</li>
+                                    <li>vpnv4</li>
+                                    <li>vpnv6</li>
                         </ul>
                 </td>
                 <td>

--- a/plugins/module_utils/network/iosxr/argspec/bgp_neighbor_address_family/bgp_neighbor_address_family.py
+++ b/plugins/module_utils/network/iosxr/argspec/bgp_neighbor_address_family/bgp_neighbor_address_family.py
@@ -50,7 +50,14 @@ class Bgp_neighbor_address_familyArgs(object):  # pylint: disable=R0903
                             "options": {
                                 "afi": {
                                     "type": "str",
-                                    "choices": ["ipv4", "ipv6"],
+                                    "choices": [
+                                        "ipv4",
+                                        "ipv6",
+                                        "l2vpn",
+                                        "link-state",
+                                        "vpnv4",
+                                        "vpnv6",
+                                    ],
                                 },
                                 "safi": {
                                     "type": "str",
@@ -70,9 +77,7 @@ class Bgp_neighbor_address_familyArgs(object):  # pylint: disable=R0903
                                     "options": {
                                         "disable": {"type": "bool"},
                                         "set": {"type": "bool"},
-                                        "send_cost_community_disable": {
-                                            "type": "bool",
-                                        },
+                                        "send_cost_community_disable": {"type": "bool"},
                                         "send_med": {
                                             "type": "dict",
                                             "options": {
@@ -84,40 +89,26 @@ class Bgp_neighbor_address_familyArgs(object):  # pylint: disable=R0903
                                 },
                                 "allowas_in": {
                                     "type": "dict",
-                                    "options": {
-                                        "value": {"type": "int"},
-                                        "set": {"type": "bool"},
-                                    },
+                                    "options": {"value": {"type": "int"}, "set": {"type": "bool"}},
                                 },
                                 "as_override": {
                                     "type": "dict",
                                     "options": {
                                         "set": {"type": "bool"},
-                                        "inheritance_disable": {
-                                            "type": "bool",
-                                        },
+                                        "inheritance_disable": {"type": "bool"},
                                     },
                                 },
-                                "bestpath_origin_as_allow_invalid": {
-                                    "type": "bool",
-                                },
+                                "bestpath_origin_as_allow_invalid": {"type": "bool"},
                                 "capability_orf_prefix": {
                                     "type": "str",
-                                    "choices": [
-                                        "both",
-                                        "send",
-                                        "none",
-                                        "receive",
-                                    ],
+                                    "choices": ["both", "send", "none", "receive"],
                                 },
                                 "default_originate": {
                                     "type": "dict",
                                     "options": {
                                         "set": {"type": "bool"},
                                         "route_policy": {"type": "str"},
-                                        "inheritance_disable": {
-                                            "type": "bool",
-                                        },
+                                        "inheritance_disable": {"type": "bool"},
                                     },
                                 },
                                 "long_lived_graceful_restart": {
@@ -140,9 +131,7 @@ class Bgp_neighbor_address_familyArgs(object):  # pylint: disable=R0903
                                         "threshold_value": {"type": "int"},
                                         "restart": {"type": "int"},
                                         "warning_only": {"type": "bool"},
-                                        "discard_extra_paths": {
-                                            "type": "bool",
-                                        },
+                                        "discard_extra_paths": {"type": "bool"},
                                     },
                                 },
                                 "multipath": {"type": "bool"},
@@ -150,33 +139,25 @@ class Bgp_neighbor_address_familyArgs(object):  # pylint: disable=R0903
                                     "type": "dict",
                                     "options": {
                                         "set": {"type": "bool"},
-                                        "inheritance_disable": {
-                                            "type": "bool",
-                                        },
+                                        "inheritance_disable": {"type": "bool"},
                                     },
                                 },
                                 "next_hop_unchanged": {
                                     "type": "dict",
                                     "options": {
                                         "set": {"type": "bool"},
-                                        "inheritance_disable": {
-                                            "type": "bool",
-                                        },
+                                        "inheritance_disable": {"type": "bool"},
                                         "multipath": {"type": "bool"},
                                     },
                                 },
-                                "optimal_route_reflection_group_name": {
-                                    "type": "str",
-                                },
+                                "optimal_route_reflection_group_name": {"type": "str"},
                                 "orf_route_policy": {"type": "str"},
                                 "origin_as": {
                                     "type": "dict",
                                     "options": {
                                         "validation": {
                                             "type": "dict",
-                                            "options": {
-                                                "disable": {"type": "bool"},
-                                            },
+                                            "options": {"disable": {"type": "bool"}},
                                         },
                                     },
                                 },
@@ -186,9 +167,7 @@ class Bgp_neighbor_address_familyArgs(object):  # pylint: disable=R0903
                                         "set": {"type": "bool"},
                                         "inbound": {"type": "bool"},
                                         "entire_aspath": {"type": "bool"},
-                                        "inheritance_disable": {
-                                            "type": "bool",
-                                        },
+                                        "inheritance_disable": {"type": "bool"},
                                     },
                                 },
                                 "route_policy": {
@@ -202,36 +181,28 @@ class Bgp_neighbor_address_familyArgs(object):  # pylint: disable=R0903
                                     "type": "dict",
                                     "options": {
                                         "set": {"type": "bool"},
-                                        "inheritance_disable": {
-                                            "type": "bool",
-                                        },
+                                        "inheritance_disable": {"type": "bool"},
                                     },
                                 },
                                 "send_community_ebgp": {
                                     "type": "dict",
                                     "options": {
                                         "set": {"type": "bool"},
-                                        "inheritance_disable": {
-                                            "type": "bool",
-                                        },
+                                        "inheritance_disable": {"type": "bool"},
                                     },
                                 },
                                 "send_community_gshut_ebgp": {
                                     "type": "dict",
                                     "options": {
                                         "set": {"type": "bool"},
-                                        "inheritance_disable": {
-                                            "type": "bool",
-                                        },
+                                        "inheritance_disable": {"type": "bool"},
                                     },
                                 },
                                 "send_extended_community_ebgp": {
                                     "type": "dict",
                                     "options": {
                                         "set": {"type": "bool"},
-                                        "inheritance_disable": {
-                                            "type": "bool",
-                                        },
+                                        "inheritance_disable": {"type": "bool"},
                                     },
                                 },
                                 "send_multicast_attributes": {
@@ -249,9 +220,7 @@ class Bgp_neighbor_address_familyArgs(object):  # pylint: disable=R0903
                                             "options": {
                                                 "set": {"type": "bool"},
                                                 "always": {"type": "bool"},
-                                                "inheritance_disable": {
-                                                    "type": "bool",
-                                                },
+                                                "inheritance_disable": {"type": "bool"},
                                             },
                                         },
                                     },
@@ -278,18 +247,12 @@ class Bgp_neighbor_address_familyArgs(object):  # pylint: disable=R0903
                             "type": "list",
                             "elements": "dict",
                             "options": {
-                                "neighbor_address": {
-                                    "type": "str",
-                                    "required": True,
-                                },
+                                "neighbor_address": {"type": "str", "required": True},
                                 "address_family": {
                                     "type": "list",
                                     "elements": "dict",
                                     "options": {
-                                        "afi": {
-                                            "type": "str",
-                                            "choices": ["ipv4", "ipv6"],
-                                        },
+                                        "afi": {"type": "str", "choices": ["ipv4", "ipv6"]},
                                         "safi": {
                                             "type": "str",
                                             "choices": [
@@ -305,18 +268,12 @@ class Bgp_neighbor_address_familyArgs(object):  # pylint: disable=R0903
                                             "options": {
                                                 "disable": {"type": "bool"},
                                                 "set": {"type": "bool"},
-                                                "send_cost_community_disable": {
-                                                    "type": "bool",
-                                                },
+                                                "send_cost_community_disable": {"type": "bool"},
                                                 "send_med": {
                                                     "type": "dict",
                                                     "options": {
-                                                        "set": {
-                                                            "type": "bool",
-                                                        },
-                                                        "disable": {
-                                                            "type": "bool",
-                                                        },
+                                                        "set": {"type": "bool"},
+                                                        "disable": {"type": "bool"},
                                                     },
                                                 },
                                             },
@@ -332,30 +289,19 @@ class Bgp_neighbor_address_familyArgs(object):  # pylint: disable=R0903
                                             "type": "dict",
                                             "options": {
                                                 "set": {"type": "bool"},
-                                                "inheritance_disable": {
-                                                    "type": "bool",
-                                                },
+                                                "inheritance_disable": {"type": "bool"},
                                             },
                                         },
                                         "capability_orf_prefix": {
                                             "type": "str",
-                                            "choices": [
-                                                "both",
-                                                "send",
-                                                "none",
-                                                "receive",
-                                            ],
+                                            "choices": ["both", "send", "none", "receive"],
                                         },
                                         "default_originate": {
                                             "type": "dict",
                                             "options": {
                                                 "set": {"type": "bool"},
-                                                "route_policy": {
-                                                    "type": "str",
-                                                },
-                                                "inheritance_disable": {
-                                                    "type": "bool",
-                                                },
+                                                "route_policy": {"type": "str"},
+                                                "inheritance_disable": {"type": "bool"},
                                             },
                                         },
                                         "long_lived_graceful_restart": {
@@ -365,12 +311,8 @@ class Bgp_neighbor_address_familyArgs(object):  # pylint: disable=R0903
                                                 "stale_time": {
                                                     "type": "dict",
                                                     "options": {
-                                                        "send": {
-                                                            "type": "int",
-                                                        },
-                                                        "accept": {
-                                                            "type": "int",
-                                                        },
+                                                        "send": {"type": "int"},
+                                                        "accept": {"type": "int"},
                                                     },
                                                 },
                                             },
@@ -379,16 +321,10 @@ class Bgp_neighbor_address_familyArgs(object):  # pylint: disable=R0903
                                             "type": "dict",
                                             "options": {
                                                 "max_limit": {"type": "int"},
-                                                "threshold_value": {
-                                                    "type": "int",
-                                                },
+                                                "threshold_value": {"type": "int"},
                                                 "restart": {"type": "int"},
-                                                "warning_only": {
-                                                    "type": "bool",
-                                                },
-                                                "discard_extra_paths": {
-                                                    "type": "bool",
-                                                },
+                                                "warning_only": {"type": "bool"},
+                                                "discard_extra_paths": {"type": "bool"},
                                             },
                                         },
                                         "multipath": {"type": "bool"},
@@ -396,36 +332,26 @@ class Bgp_neighbor_address_familyArgs(object):  # pylint: disable=R0903
                                             "type": "dict",
                                             "options": {
                                                 "set": {"type": "bool"},
-                                                "inheritance_disable": {
-                                                    "type": "bool",
-                                                },
+                                                "inheritance_disable": {"type": "bool"},
                                             },
                                         },
                                         "next_hop_unchanged": {
                                             "type": "dict",
                                             "options": {
                                                 "set": {"type": "bool"},
-                                                "inheritance_disable": {
-                                                    "type": "bool",
-                                                },
+                                                "inheritance_disable": {"type": "bool"},
                                                 "multipath": {"type": "bool"},
                                             },
                                         },
-                                        "optimal_route_reflection_group_name": {
-                                            "type": "str",
-                                        },
+                                        "optimal_route_reflection_group_name": {"type": "str"},
                                         "orf_route_policy": {"type": "str"},
                                         "remove_private_AS": {
                                             "type": "dict",
                                             "options": {
                                                 "set": {"type": "bool"},
                                                 "inbound": {"type": "bool"},
-                                                "entire_aspath": {
-                                                    "type": "bool",
-                                                },
-                                                "inheritance_disable": {
-                                                    "type": "bool",
-                                                },
+                                                "entire_aspath": {"type": "bool"},
+                                                "inheritance_disable": {"type": "bool"},
                                             },
                                         },
                                         "route_policy": {
@@ -439,36 +365,28 @@ class Bgp_neighbor_address_familyArgs(object):  # pylint: disable=R0903
                                             "type": "dict",
                                             "options": {
                                                 "set": {"type": "bool"},
-                                                "inheritance_disable": {
-                                                    "type": "bool",
-                                                },
+                                                "inheritance_disable": {"type": "bool"},
                                             },
                                         },
                                         "send_community_ebgp": {
                                             "type": "dict",
                                             "options": {
                                                 "set": {"type": "bool"},
-                                                "inheritance_disable": {
-                                                    "type": "bool",
-                                                },
+                                                "inheritance_disable": {"type": "bool"},
                                             },
                                         },
                                         "send_community_gshut_ebgp": {
                                             "type": "dict",
                                             "options": {
                                                 "set": {"type": "bool"},
-                                                "inheritance_disable": {
-                                                    "type": "bool",
-                                                },
+                                                "inheritance_disable": {"type": "bool"},
                                             },
                                         },
                                         "send_extended_community_ebgp": {
                                             "type": "dict",
                                             "options": {
                                                 "set": {"type": "bool"},
-                                                "inheritance_disable": {
-                                                    "type": "bool",
-                                                },
+                                                "inheritance_disable": {"type": "bool"},
                                             },
                                         },
                                         "soft_reconfiguration": {
@@ -477,15 +395,9 @@ class Bgp_neighbor_address_familyArgs(object):  # pylint: disable=R0903
                                                 "inbound": {
                                                     "type": "dict",
                                                     "options": {
-                                                        "set": {
-                                                            "type": "bool",
-                                                        },
-                                                        "always": {
-                                                            "type": "bool",
-                                                        },
-                                                        "inheritance_disable": {
-                                                            "type": "bool",
-                                                        },
+                                                        "set": {"type": "bool"},
+                                                        "always": {"type": "bool"},
+                                                        "inheritance_disable": {"type": "bool"},
                                                     },
                                                 },
                                             },

--- a/plugins/modules/iosxr_bgp_neighbor_address_family.py
+++ b/plugins/modules/iosxr_bgp_neighbor_address_family.py
@@ -45,10 +45,10 @@ options:
                 type: list
                 elements: dict
                 suboptions:
-                  afi: &afi
+                  afi:
                     description: address family.
                     type: str
-                    choices: [ 'ipv4', 'ipv6', 'l2vpn', 'link-state', 'vpnv4', 'vpnv6',]
+                    choices: [ 'ipv4', 'ipv6', 'l2vpn', 'link-state', 'vpnv4', 'vpnv6']
                   safi:
                     description: Address Family modifier
                     type: str
@@ -327,7 +327,10 @@ options:
                     type: list
                     elements: dict
                     suboptions:
-                      afi: *afi
+                      afi:
+                        description: address family.
+                        type: str
+                        choices: [ 'ipv4', 'ipv6']
                       safi:
                         description: Address Family modifier
                         type: str

--- a/plugins/modules/iosxr_bgp_neighbor_address_family.py
+++ b/plugins/modules/iosxr_bgp_neighbor_address_family.py
@@ -48,7 +48,7 @@ options:
                   afi: &afi
                     description: address family.
                     type: str
-                    choices: [ 'ipv4', 'ipv6']
+                    choices: [ 'ipv4', 'ipv6', 'l2vpn', 'link-state', 'vpnv4', 'vpnv6',]
                   safi:
                     description: Address Family modifier
                     type: str

--- a/tests/unit/modules/network/iosxr/test_iosxr_bgp_neighbor_address_family.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_bgp_neighbor_address_family.py
@@ -128,26 +128,17 @@ class TestIosxrBgpNeighborAddressFamilyModule(TestIosxrModule):
                                     default_originate=dict(set=True),
                                     capability_orf_prefix="both",
                                     send_multicast_attributes=dict(set=True),
-                                    soft_reconfiguration=dict(
-                                        inbound=dict(set=True),
-                                    ),
+                                    soft_reconfiguration=dict(inbound=dict(set=True)),
                                     send_community_gshut_ebgp=dict(set=True),
-                                    send_extended_community_ebgp=dict(
-                                        set=True,
-                                    ),
+                                    send_extended_community_ebgp=dict(set=True),
                                     send_community_ebgp=dict(set=True),
-                                    origin_as=dict(
-                                        validation=dict(disable=True),
-                                    ),
+                                    origin_as=dict(validation=dict(disable=True)),
                                     remove_private_AS=dict(
                                         set=True,
                                         inbound=True,
                                         entire_aspath=True,
                                     ),
-                                    route_policy=dict(
-                                        inbound="test1",
-                                        outbound="test1",
-                                    ),
+                                    route_policy=dict(inbound="test1", outbound="test1"),
                                     maximum_prefix=dict(
                                         max_limit=10,
                                         threshold_value=20,
@@ -155,10 +146,7 @@ class TestIosxrBgpNeighborAddressFamilyModule(TestIosxrModule):
                                     ),
                                     next_hop_self=dict(set=True),
                                     next_hop_unchanged=dict(multipath=True),
-                                    aigp=dict(
-                                        set=True,
-                                        send_med=dict(set=True),
-                                    ),
+                                    aigp=dict(set=True, send_med=dict(set=True)),
                                     as_override=dict(set=True),
                                     allowas_in=dict(value=4),
                                     bestpath_origin_as_allow_invalid=True,
@@ -211,26 +199,17 @@ class TestIosxrBgpNeighborAddressFamilyModule(TestIosxrModule):
                                     default_originate=dict(set=True),
                                     capability_orf_prefix="both",
                                     send_multicast_attributes=dict(set=True),
-                                    soft_reconfiguration=dict(
-                                        inbound=dict(set=True),
-                                    ),
+                                    soft_reconfiguration=dict(inbound=dict(set=True)),
                                     send_community_gshut_ebgp=dict(set=True),
-                                    send_extended_community_ebgp=dict(
-                                        set=True,
-                                    ),
+                                    send_extended_community_ebgp=dict(set=True),
                                     send_community_ebgp=dict(set=True),
-                                    origin_as=dict(
-                                        validation=dict(disable=True),
-                                    ),
+                                    origin_as=dict(validation=dict(disable=True)),
                                     remove_private_AS=dict(
                                         set=True,
                                         inbound=True,
                                         entire_aspath=True,
                                     ),
-                                    route_policy=dict(
-                                        inbound="test1",
-                                        outbound="test1",
-                                    ),
+                                    route_policy=dict(inbound="test1", outbound="test1"),
                                     maximum_prefix=dict(
                                         max_limit=10,
                                         threshold_value=20,
@@ -238,10 +217,7 @@ class TestIosxrBgpNeighborAddressFamilyModule(TestIosxrModule):
                                     ),
                                     next_hop_self=dict(set=True),
                                     next_hop_unchanged=dict(multipath=True),
-                                    aigp=dict(
-                                        set=True,
-                                        send_med=dict(set=True),
-                                    ),
+                                    aigp=dict(set=True, send_med=dict(set=True)),
                                     as_override=dict(set=True),
                                     bestpath_origin_as_allow_invalid=True,
                                     long_lived_graceful_restart=dict(
@@ -344,10 +320,7 @@ class TestIosxrBgpNeighborAddressFamilyModule(TestIosxrModule):
                                             safi="unicast",
                                             multipath=True,
                                             default_originate=dict(set=True),
-                                            route_policy=dict(
-                                                inbound="test1",
-                                                outbound="test1",
-                                            ),
+                                            route_policy=dict(inbound="test1", outbound="test1"),
                                         ),
                                     ],
                                 ),
@@ -534,17 +507,11 @@ class TestIosxrBgpNeighborAddressFamilyModule(TestIosxrModule):
                                     default_originate=dict(set=True),
                                     capability_orf_prefix="both",
                                     send_multicast_attributes=dict(set=True),
-                                    soft_reconfiguration=dict(
-                                        inbound=dict(set=True),
-                                    ),
+                                    soft_reconfiguration=dict(inbound=dict(set=True)),
                                     send_community_gshut_ebgp=dict(set=True),
-                                    send_extended_community_ebgp=dict(
-                                        set=True,
-                                    ),
+                                    send_extended_community_ebgp=dict(set=True),
                                     send_community_ebgp=dict(set=True),
-                                    origin_as=dict(
-                                        validation=dict(disable=True),
-                                    ),
+                                    origin_as=dict(validation=dict(disable=True)),
                                     remove_private_AS=dict(
                                         set=True,
                                         inbound=True,
@@ -557,10 +524,7 @@ class TestIosxrBgpNeighborAddressFamilyModule(TestIosxrModule):
                                     ),
                                     next_hop_self=dict(set=True),
                                     next_hop_unchanged=dict(multipath=True),
-                                    aigp=dict(
-                                        set=True,
-                                        send_med=dict(set=True),
-                                    ),
+                                    aigp=dict(set=True, send_med=dict(set=True)),
                                     as_override=dict(set=True),
                                     allowas_in=dict(value=4),
                                     bestpath_origin_as_allow_invalid=True,
@@ -650,9 +614,7 @@ class TestIosxrBgpNeighborAddressFamilyModule(TestIosxrModule):
                             },
                             "safi": "unicast",
                             "send_community_ebgp": {"set": True},
-                            "send_community_gshut_ebgp": {
-                                "inheritance_disable": True,
-                            },
+                            "send_community_gshut_ebgp": {"inheritance_disable": True},
                             "send_extended_community_ebgp": {"set": True},
                             "send_multicast_attributes": {"set": True},
                             "weight": 0,
@@ -664,6 +626,122 @@ class TestIosxrBgpNeighborAddressFamilyModule(TestIosxrModule):
         }
 
         self.assertEqual(parsed_list, result["parsed"])
+
+    def test_iosxr_bgp_add_fam_parsed(self):
+        self.maxDiff = None
+        set_module_args(
+            dict(
+                running_config="router bgp 1\n bgp router-id 1.2.1.3\n neighbor 1.1.1.1\n  "
+                "remote-as 6\n  address-family vpnv4 unicast\n   origin-as validation disable\n   "
+                "bestpath origin-as allow invalid\n   weight 0\n   send-community-ebgp\n  "
+                " multipath\n   allowas-in 3\n   maximum-prefix 1 1 discard-extra-paths\n"
+                "   capability orf prefix both\n   "
+                "next-hop-unchanged multipath\n  !\n  "
+                "!\n !",
+                state="parsed",
+            ),
+        )
+        result = self.execute_module(changed=False)
+        parsed_list = {
+            "as_number": "1",
+            "neighbors": [
+                {
+                    "neighbor_address": "1.1.1.1",
+                    "address_family": [
+                        {
+                            "afi": "vpnv4",
+                            "safi": "unicast",
+                            "origin_as": {"validation": {"disable": True}},
+                            "bestpath_origin_as_allow_invalid": True,
+                            "weight": 0,
+                            "send_community_ebgp": {"set": True},
+                            "multipath": True,
+                            "allowas_in": {"value": 3},
+                            "capability_orf_prefix": "both",
+                            "next_hop_unchanged": {"multipath": True},
+                        },
+                    ],
+                },
+            ],
+        }
+
+        self.assertEqual(parsed_list, result["parsed"])
+
+    def test_iosxr_bgp_nbr_af_afi_replaced(self):
+        self.maxDiff = None
+        set_module_args(
+            dict(
+                config=dict(
+                    as_number="1",
+                    neighbors=[
+                        dict(
+                            neighbor_address="1.1.1.1",
+                            address_family=[
+                                dict(
+                                    afi="vpnv4",
+                                    safi="flowspec",
+                                    multipath=True,
+                                    default_originate=dict(set=True),
+                                    capability_orf_prefix="both",
+                                    send_multicast_attributes=dict(set=True),
+                                    soft_reconfiguration=dict(inbound=dict(set=True)),
+                                    send_community_gshut_ebgp=dict(set=True),
+                                    send_extended_community_ebgp=dict(set=True),
+                                    send_community_ebgp=dict(set=True),
+                                    origin_as=dict(validation=dict(disable=True)),
+                                    remove_private_AS=dict(
+                                        set=True,
+                                        inbound=True,
+                                        entire_aspath=True,
+                                    ),
+                                    route_policy=dict(inbound="test1", outbound="test1"),
+                                    maximum_prefix=dict(
+                                        max_limit=10,
+                                        threshold_value=20,
+                                        restart=10,
+                                    ),
+                                    next_hop_self=dict(set=True),
+                                    next_hop_unchanged=dict(multipath=True),
+                                    aigp=dict(set=True, send_med=dict(set=True)),
+                                    as_override=dict(set=True),
+                                    bestpath_origin_as_allow_invalid=True,
+                                    long_lived_graceful_restart=dict(
+                                        stale_time=dict(send=20, accept=30),
+                                    ),
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+                state="replaced",
+            ),
+        )
+        commands = [
+            "address-family vpnv4 flowspec",
+            "aigp",
+            "aigp send med",
+            "as-override",
+            "bestpath origin-as allow invalid",
+            "capability orf prefix both",
+            "default-originate",
+            "maximum-prefix 10 20 restart 10",
+            "multipath",
+            "neighbor 1.1.1.1",
+            "next-hop-self",
+            "next-hop-unchanged multipath",
+            "origin-as validation disable",
+            "remove-private-AS inbound entire-aspath",
+            "route-policy test1 in",
+            "route-policy test1 out",
+            "router bgp 1",
+            "send-community-ebgp",
+            "send-community-gshut-ebgp",
+            "send-extended-community-ebgp",
+            "send-multicast-attributes",
+            "soft-reconfiguration inbound",
+        ]
+        result = self.execute_module(changed=True)
+        self.assertEqual(sorted(result["commands"]), sorted(commands))
 
     def test_iosxr_bgp_nbr_af_overridden(self):
         run_cfg = dedent(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
add extra supported values to afi attribute
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
bgp_neighbor_address_family

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
                  afi:
                    description: address family.
                    choices: [ 'ipv4', 'ipv6', 'l2vpn', 'link-state', 'vpnv4', 'vpnv6',]
```
