### PR TITLE
requirements: remove google dependency

### DIFF
--- a/changelogs/fragments/remove_google_dependency.yaml
+++ b/changelogs/fragments/remove_google_dependency.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "requirements: remove google dependency"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ ncclient
 paramiko
 ipaddress
 ansible-pylibssh
-google
 grpcio
 protobuf


### PR DESCRIPTION
##### SUMMARY
The google dependency has been added in a8ba926 but is never uses by this collection.
Moreover, the PyPi google library provides the googlesearch module [1] while the commit introducing the change was only about grpc connection via the protobuf library (which provides the google.protobuf module).

[1] https://pypi.org/project/google

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
requirements

