### PR TITLE
Allow running `admin show` arguments in check_mode

### DIFF
--- a/plugins/modules/iosxr_command.py
+++ b/plugins/modules/iosxr_command.py
@@ -152,7 +152,7 @@ def parse_commands(module, warnings):
             command = item["command"]
         except Exception:
             command = item
-        if module.check_mode and not command.startswith("show"):
+        if module.check_mode and not (command.startswith("show") or command.startswith("admin show")):
             warnings.append(
                 "Only show commands are supported when using check mode, not "
                 "executing %s" % command,


### PR DESCRIPTION


##### SUMMARY
The `show` command filter was unaware of `admin` class commands which are invoked by `admin show`. This patch fixes the problem to allow these commands in check mode.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cisco.iosxr.iosxr_command

##### ADDITIONAL INFORMATION

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
cisco.iosxr.iosxr_command:
  commands:
  - admin show running-config
  check_mode: true
  register: admin_running_config
```

produces 

```
[WARNING]: Only show commands are supported when using check mode, not executing admin show running-config
```

With the changes here, the command now runs successfully.