### PR TITLE
add build ignore list to galaxy.yml

### DIFF
--- a/changelogs/fragments/fix_build_includes.yaml
+++ b/changelogs/fragments/fix_build_includes.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - remove linting configs and test files from the collection build

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -14,3 +14,13 @@ tags: [cisco, iosxr, networking, netconf]
 # NOTE(pabelanger): We create an empty version key to keep ansible-galaxy
 # happy. We dynamically inject version info based on git information.
 version: "6.0.1"
+build_ignore:
+  - .ansible-lint
+  - .github
+  - .yamllint.yml 
+  - codecov.yml
+  - pyproject.toml
+  - test-requirements.txt
+  - '*.tar.gz'
+  - tests
+  - tox.ini

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -17,10 +17,10 @@ version: "6.0.1"
 build_ignore:
   - .ansible-lint
   - .github
-  - .yamllint.yml 
+  - .yamllint.yml
   - codecov.yml
   - pyproject.toml
   - test-requirements.txt
-  - '*.tar.gz'
+  - "*.tar.gz"
   - tests
   - tox.ini


### PR DESCRIPTION
##### SUMMARY
The following files have been causing alerts on customers security scans
RSA Private Key
collections/ansible_collections/cisco/ios/tests/integration/targets/ios_user/files/test_rsa
Generic High Entropy Secret
collections/ansible_collections/cisco/iosxr/plugins/modules/iosxr_user.py
RSA Private Key
collections/ansible_collections/cisco/iosxr/tests/integration/targets/iosxr_user/files/private

The solution should be that we don't distribute the test files in our galaxy build tarballs. They are fine in tests, just need to not distribute them. This PR achieves that.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
Test Files