### PR TITLE
Bug453 port group

### DIFF
--- a/docs/cisco.iosxr.iosxr_acls_module.rst
+++ b/docs/cisco.iosxr.iosxr_acls_module.rst
@@ -233,26 +233,7 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>port_group</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">string</span>
-                    </div>
-                </td>
-                <td>
-                </td>
-                <td>
-                        <div>Name of port-group.</div>
-                </td>
-            </tr>
-            <tr>
-                    <td class="elbow-placeholder"></td>
-                    <td class="elbow-placeholder"></td>
-                    <td class="elbow-placeholder"></td>
-                    <td class="elbow-placeholder"></td>
-                <td colspan="3">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>port_protocol</b>
+                    <bport_protocol</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">dictionary</span>
@@ -282,6 +263,26 @@ Parameters
                 </td>
                 <td>
                         <div>Match only packets on a given port number.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port-group</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Match only packets with group of port numbers.</div>
                 </td>
             </tr>
             <tr>
@@ -3561,25 +3562,6 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>port_group</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">string</span>
-                    </div>
-                </td>
-                <td>
-                </td>
-                <td>
-                        <div>Name of port-group.</div>
-                </td>
-            </tr>
-            <tr>
-                    <td class="elbow-placeholder"></td>
-                    <td class="elbow-placeholder"></td>
-                    <td class="elbow-placeholder"></td>
-                    <td class="elbow-placeholder"></td>
-                <td colspan="3">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>port_protocol</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -3630,6 +3612,26 @@ Parameters
                 </td>
                 <td>
                         <div>Match only packets with a greater port number.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port-group</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Match only packets with group of port numbers.</div>
                 </td>
             </tr>
             <tr>

--- a/plugins/module_utils/network/iosxr/argspec/acls/acls.py
+++ b/plugins/module_utils/network/iosxr/argspec/acls/acls.py
@@ -60,7 +60,6 @@ class AclsArgs(object):  # pylint: disable=R0903
                                             "host",
                                             "prefix",
                                             "net_group",
-                                            "port_group",
                                         ],
                                         [
                                             "wildcard_bits",
@@ -68,13 +67,11 @@ class AclsArgs(object):  # pylint: disable=R0903
                                             "host",
                                             "prefix",
                                             "net_group",
-                                            "port_group",
                                         ],
                                     ],
                                     "options": {
                                         "host": {"type": "str"},
                                         "net_group": {"type": "str"},
-                                        "port_group": {"type": "str"},
                                         "address": {"type": "str"},
                                         "any": {"type": "bool"},
                                         "prefix": {"type": "str"},
@@ -85,6 +82,7 @@ class AclsArgs(object):  # pylint: disable=R0903
                                                     "gt",
                                                     "lt",
                                                     "neq",
+                                                    "port_group",
                                                     "range",
                                                 ],
                                             ],
@@ -93,6 +91,7 @@ class AclsArgs(object):  # pylint: disable=R0903
                                                 "gt": {"type": "str"},
                                                 "lt": {"type": "str"},
                                                 "neq": {"type": "str"},
+                                                "port_group": {"type": "str"},
                                                 "range": {
                                                     "options": {
                                                         "end": {"type": "str"},
@@ -456,7 +455,6 @@ class AclsArgs(object):  # pylint: disable=R0903
                                             "host",
                                             "prefix",
                                             "net_group",
-                                            "port_group",
                                         ],
                                         [
                                             "wildcard_bits",
@@ -464,13 +462,11 @@ class AclsArgs(object):  # pylint: disable=R0903
                                             "host",
                                             "prefix",
                                             "net_group",
-                                            "port_group",
                                         ],
                                     ],
                                     "options": {
                                         "host": {"type": "str"},
                                         "net_group": {"type": "str"},
-                                        "port_group": {"type": "str"},
                                         "address": {"type": "str"},
                                         "any": {"type": "bool"},
                                         "prefix": {"type": "str"},
@@ -481,6 +477,7 @@ class AclsArgs(object):  # pylint: disable=R0903
                                                     "gt",
                                                     "lt",
                                                     "neq",
+                                                    "port_group",
                                                     "range",
                                                 ],
                                             ],
@@ -489,6 +486,7 @@ class AclsArgs(object):  # pylint: disable=R0903
                                                 "gt": {"type": "str"},
                                                 "lt": {"type": "str"},
                                                 "neq": {"type": "str"},
+                                                "port_group": {"type": "str"},
                                                 "range": {
                                                     "options": {
                                                         "end": {"type": "str"},

--- a/plugins/module_utils/network/iosxr/config/acls/acls.py
+++ b/plugins/module_utils/network/iosxr/config/acls/acls.py
@@ -374,8 +374,6 @@ class Acls(ConfigBase):
                 cmd += "host {0} ".format(dir_dict["host"])
             elif "net_group" in dir_dict:
                 cmd += "net-group {0} ".format(dir_dict["net_group"])
-            elif "port_group" in dir_dict:
-                cmd += "port-group {0} ".format(dir_dict["port_group"])
             elif "prefix" in dir_dict:
                 cmd += "{0} ".format(dir_dict["prefix"])
             else:
@@ -386,11 +384,15 @@ class Acls(ConfigBase):
 
             if "port_protocol" in dir_dict:
                 protocol_range = dir_dict["port_protocol"].get("range")
+                port_group = dir_dict["port_protocol"].get("port_group")
                 if protocol_range:
                     cmd += "range {0} {1} ".format(
                         protocol_range["start"],
                         protocol_range["end"],
                     )
+                elif port_group:
+                    for key, value in iteritems(dir_dict["port_protocol"]):
+                        cmd += "port-group {1} ".format(key, value)
                 else:
                     for key, value in iteritems(dir_dict["port_protocol"]):
                         cmd += "{0} {1} ".format(key, value)


### PR DESCRIPTION
##### SUMMARY
<!--- -->
The iosxr acls module was wrongly setting port-group param to be mutually exclusive with net-group,host,address,any and prefix in source and destination of ACE. The following ACE was correct and was a part of ACL on cisco ios xr9k series router. 1390 permit udp any 1.1.1.1 0.0.0.0 port-group ABC

As can be seen the [address(1.1.1.1), wildcard(0.0.0.0)] and port-group(ABC) are placed together, which as per previously implemented logic of iosxr.acls ansible module was inconsistent and should be mutually exclusive.

I have modified the iosxr.acls module to now fix this problem, moreover removed the port-group as  direct option to the source/destination and moved it under the port_protocol options. Also updated the ansible-doc for it. 

This fixes #453 
<!--- HINT: Include "Fixes #453" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- cisco.iosxr.iosxr_acls-->
cisco.iosxr.iosxr_acls
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
