### PR TITLE
Fixes module_defaults being incorrectly applied to platform actions

### DIFF
--- a/changelogs/fragments/module_defaults.yaml
+++ b/changelogs/fragments/module_defaults.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Prevents module_defaults from were being incorrectly applied to the platform action, instead of the concerned module.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -4,68 +4,99 @@ plugin_routing:
   modules:
     acl_interfaces:
       redirect: cisco.iosxr.iosxr_acl_interfaces
+      action_plugin: cisco.iosxr.iosxr
     acls:
       redirect: cisco.iosxr.iosxr_acls
+      action_plugin: cisco.iosxr.iosxr
     banner:
       redirect: cisco.iosxr.iosxr_banner
+      action_plugin: cisco.iosxr.iosxr
     command:
       redirect: cisco.iosxr.iosxr_command
+      action_plugin: cisco.iosxr.iosxr
     config:
       redirect: cisco.iosxr.iosxr_config
+      action_plugin: cisco.iosxr.iosxr
     facts:
       redirect: cisco.iosxr.iosxr_facts
+      action_plugin: cisco.iosxr.iosxr
     interfaces:
       redirect: cisco.iosxr.iosxr_interfaces
+      action_plugin: cisco.iosxr.iosxr
     l2_interfaces:
       redirect: cisco.iosxr.iosxr_l2_interfaces
+      action_plugin: cisco.iosxr.iosxr
     l3_interfaces:
       redirect: cisco.iosxr.iosxr_l3_interfaces
+      action_plugin: cisco.iosxr.iosxr
     lacp:
       redirect: cisco.iosxr.iosxr_lacp
+      action_plugin: cisco.iosxr.iosxr
     lacp_interfaces:
       redirect: cisco.iosxr.iosxr_lacp_interfaces
+      action_plugin: cisco.iosxr.iosxr
     lag_interfaces:
       redirect: cisco.iosxr.iosxr_lag_interfaces
+      action_plugin: cisco.iosxr.iosxr
     lldp_global:
       redirect: cisco.iosxr.iosxr_lldp_global
+      action_plugin: cisco.iosxr.iosxr
     lldp_interfaces:
       redirect: cisco.iosxr.iosxr_lldp_interfaces
+      action_plugin: cisco.iosxr.iosxr
     logging:
       redirect: cisco.iosxr.iosxr_logging
       deprecation:
         removal_date: "2023-08-01"
         warning_text: See the plugin documentation for more details
+      action_plugin: cisco.iosxr.iosxr
     iosxr_logging:
       deprecation:
         removal_date: "2023-08-01"
         warning_text: See the plugin documentation for more details
+      action_plugin: cisco.iosxr.iosxr
     logging_global:
       redirect: cisco.iosxr.iosxr_logging_global
+      action_plugin: cisco.iosxr.iosxr
     netconf:
       redirect: cisco.iosxr.iosxr_netconf
+      action_plugin: cisco.iosxr.iosxr
     ospfv2:
       redirect: cisco.iosxr.iosxr_ospfv2
+      action_plugin: cisco.iosxr.iosxr
     ospfv3:
       redirect: cisco.iosxr.iosxr_ospfv3
+      action_plugin: cisco.iosxr.iosxr
     ospf_interfaces:
       redirect: cisco.iosxr.iosxr_ospf_interfaces
+      action_plugin: cisco.iosxr.iosxr
     static_routes:
       redirect: cisco.iosxr.iosxr_static_routes
+      action_plugin: cisco.iosxr.iosxr
     system:
       redirect: cisco.iosxr.iosxr_system
+      action_plugin: cisco.iosxr.iosxr
     user:
       redirect: cisco.iosxr.iosxr_user
+      action_plugin: cisco.iosxr.iosxr
     bgp_neighbor_address_family:
       redirect: cisco.iosxr.iosxr_bgp_neighbor_address_family
+      action_plugin: cisco.iosxr.iosxr
     bgp_address_family:
       redirect: cisco.iosxr.iosxr_bgp_address_family
+      action_plugin: cisco.iosxr.iosxr
     bgp_global:
       redirect: cisco.iosxr.iosxr_bgp_global
+      action_plugin: cisco.iosxr.iosxr
     prefix_lists:
       redirect: cisco.iosxr.iosxr_prefix_lists
+      action_plugin: cisco.iosxr.iosxr
     ntp_global:
       redirect: cisco.iosxr.iosxr_ntp_global
+      action_plugin: cisco.iosxr.iosxr
     snmp_server:
       redirect: cisco.iosxr.iosxr_snmp_server
+      action_plugin: cisco.iosxr.iosxr
     hostname:
       redirect: cisco.iosxr.iosxr_hostname
+      action_plugin: cisco.iosxr.iosxr

--- a/plugins/action/acl_interfaces.py
+++ b/plugins/action/acl_interfaces.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/acls.py
+++ b/plugins/action/acls.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/banner.py
+++ b/plugins/action/banner.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/bgp.py
+++ b/plugins/action/bgp.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/bgp_address_family.py
+++ b/plugins/action/bgp_address_family.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/bgp_global.py
+++ b/plugins/action/bgp_global.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/bgp_neighbor_address_family.py
+++ b/plugins/action/bgp_neighbor_address_family.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/command.py
+++ b/plugins/action/command.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/config.py
+++ b/plugins/action/config.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/facts.py
+++ b/plugins/action/facts.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/hostname.py
+++ b/plugins/action/hostname.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/interface.py
+++ b/plugins/action/interface.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/interfaces.py
+++ b/plugins/action/interfaces.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/l2_interfaces.py
+++ b/plugins/action/l2_interfaces.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/l3_interfaces.py
+++ b/plugins/action/l3_interfaces.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/lacp.py
+++ b/plugins/action/lacp.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/lacp_interfaces.py
+++ b/plugins/action/lacp_interfaces.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/lag_interfaces.py
+++ b/plugins/action/lag_interfaces.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/lldp_global.py
+++ b/plugins/action/lldp_global.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/lldp_interfaces.py
+++ b/plugins/action/lldp_interfaces.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/logging.py
+++ b/plugins/action/logging.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/logging_global.py
+++ b/plugins/action/logging_global.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/netconf.py
+++ b/plugins/action/netconf.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/ntp_global.py
+++ b/plugins/action/ntp_global.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/ospf_interfaces.py
+++ b/plugins/action/ospf_interfaces.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/ospfv2.py
+++ b/plugins/action/ospfv2.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/ospfv3.py
+++ b/plugins/action/ospfv3.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/prefix_lists.py
+++ b/plugins/action/prefix_lists.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/snmp_server.py
+++ b/plugins/action/snmp_server.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/static_routes.py
+++ b/plugins/action/static_routes.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/system.py
+++ b/plugins/action/system.py
@@ -1,1 +1,0 @@
-iosxr.py

--- a/plugins/action/user.py
+++ b/plugins/action/user.py
@@ -1,1 +1,0 @@
-iosxr.py


### PR DESCRIPTION
##### SUMMARY

- Prevents module_defaults from were being incorrectly applied to the platform action, instead of the concerned module.
- As an example, setting module_defaults at play level for *_facts did not work due to this issue.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
meta/runtime.yml