### PR TITLE
[cliconf] changes required after cliconfbase updates in ansible.netcommon#640

### DIFF
--- a/plugins/cliconf/iosxr.py
+++ b/plugins/cliconf/iosxr.py
@@ -308,6 +308,11 @@ class Cliconf(CliconfBase):
         exclusive=False,
         label=None,
     ):
+        if diff:
+            self._connection.queue_message(
+                "warning",
+                message="setting `diff=True` in edit_config() results in failing sanity checks",
+            )
         operations = self.get_device_operations()
         self.check_edit_config_capability(operations, candidate, commit, replace, comment)
 


### PR DESCRIPTION
##### SUMMARY
- Mostly described in https://github.com/ansible-collections/ansible.netcommon/pull/640.
- Summary: `err_responses` cannot be added in edit_config base signature, this breaks other platforms. The fact that edit_config base has `diff` kwarg and iosxr cliconf edit_config results in sanity/pylint to trip if `err_responses` isn't added in edit_config base.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
cliconf/iosxr.py

