### PR TITLE
fix the small typo in integration test

### DIFF
--- a/tests/integration/targets/iosxr_vrf_address_family/tests/common/empty_config.yaml
+++ b/tests/integration/targets/iosxr_vrf_address_family/tests/common/empty_config.yaml
@@ -27,7 +27,7 @@
 - name: Overridden with empty configuration should give appropriate error message
   register: result
   ignore_errors: true
-  cisco.ios.ios_vrf_address_family:
+  cisco.iosxr.iosxr_vrf_address_family:
     config:
     state: overridden
 

--- a/tests/integration/targets/iosxr_vrf_address_family/tests/common/gathered.yaml
+++ b/tests/integration/targets/iosxr_vrf_address_family/tests/common/gathered.yaml
@@ -17,6 +17,7 @@
       ansible.builtin.assert:
         that:
           - result.changed == false
+          - gathered['after'] == result['gathered']
 
   always:
     - ansible.builtin.include_tasks: _remove_config.yaml

--- a/tests/integration/targets/iosxr_vrf_address_family/vars/main.yaml
+++ b/tests/integration/targets/iosxr_vrf_address_family/vars/main.yaml
@@ -39,7 +39,6 @@ merged:
                 advertise_as_vpn: true
           maximum:
             prefix: 100
-    - name: VRF5
 
 replaced:
   before:
@@ -67,7 +66,6 @@ replaced:
                 advertise_as_vpn: true
           maximum:
             prefix: 100
-    - name: VRF5
 
   commands:
     - vrf VRF6
@@ -107,7 +105,6 @@ replaced:
                 advertise_as_vpn: true
           maximum:
             prefix: 100
-    - name: VRF5
     - name: VRF6
       address_families:
         - afi: "ipv4"
@@ -132,8 +129,7 @@ replaced:
                 advertise_as_vpn: true
 
 overridden:
-  before:
-    - name: VRF5
+  before: {}
   commands:
     - vrf VRF7
     - address-family ipv4 unicast
@@ -148,7 +144,6 @@ overridden:
     - import from vrf advertise-as-vpn
     - maximum prefix 500
   after:
-    - name: VRF5
     - name: VRF7
       address_families:
         - afi: "ipv4"
@@ -177,7 +172,6 @@ overridden:
 gathered:
   after:
     - name: VRF4
-    - name: VRF5
       address_families:
         - afi: "ipv4"
           safi: "unicast"
@@ -260,4 +254,3 @@ deleted:
     - no address-family ipv4 unicast
   after:
     - name: VRF4
-    - name: VRF5


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes the small typo in integration test
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cisco.iosxr.vrf_address_family
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
CI Failure: https://main-jenkins-csb-aap.apps.ocp-c1.prod.psi.redhat.com/job/AAPQA/job/Content/job/Network/job/devel/job/cisco_iosxr-devel-network-pipeline-1/69/testReport/tests.ansible_network.test_cisco_iosxr/TestCiscoIOSXR/test_ansible_network_integration_cisco_iosxr_iosxr_vrf_address_family_/
```
