### PR TITLE
Update base.py

### DIFF
--- a/plugins/module_utils/network/iosxr/facts/legacy/base.py
+++ b/plugins/module_utils/network/iosxr/facts/legacy/base.py
@@ -308,7 +308,7 @@ class Interfaces(FactsBase):
             return match.group(1)
 
     def parse_cdp_intf_port(self, data):
-        match = re.search(r"^Interface: (.+),  Port ID \(outgoing port\): (.+)$", data, re.M)
+        match = re.search(r"^Interface: (.+)[,\n]\s*Port ID \(outgoing port\): (.+)$", data, re.M)
         if match:
             return match.group(1), match.group(2)
 
@@ -323,6 +323,6 @@ class Interfaces(FactsBase):
             return match.group(1)
 
     def parse_cdp_ip(self, data):
-        match = re.search(r"^  IP address: (.+)$", data, re.M)
+        match = re.search(r"^  IP(?:v4)? address: (.+)$", data, re.M)
         if match:
             return match.group(1)


### PR DESCRIPTION
##### SUMMARY
Update parse_cdp_intf_port and parse_cdp_ip regex - IOS-XR 7.7.21 LNT has a different "show cdp neighbors detail" output format. Namely there is a newline between the "Interface" and "Port ID" segments, and "IP address" is "IPv4 address". So devices running IOS-XR 7.7.21 would not have their CDP neighbors collected. Also replicated on non-LNT IOS-XR 7.4.1.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
cisco.iosxr: ansible_net_neighbors
plugins/module_utils/network/iosxr/facts/legacy/base.py

##### ADDITIONAL INFORMATION
Output before change:
```
{
[...]
    "ansible_net_neighbors": {}
[...]
}
```

Output after change:
```
{
[...]
    "ansible_net_neighbors": [
        "HundredGigE0/0/0/31": [
            {
                "host": "LABASR11",
                "platform": "cisco ASR9K",
                "port": "HundredGigE0/3/0/0",
                "ip": "10.250.1.29"
            }
        ],
        "TenGigE0/0/0/22": [
            {
                "host": "LABASR34.kfn.local",
                "platform": "cisco ASR-920-24SZ-M",
                "port": "TenGigabitEthernet0/0/27",
                "ip": "10.250.1.102"
            }
        ],
        "TenGigE0/0/0/23": [
            {
                "host": "LABASR33.kfn.local",
                "platform": "cisco ASR-920-24SZ-M",
                "port": "TenGigabitEthernet0/0/27",
                "ip": "10.250.1.97"
            }
        ],
        "TenGigE0/0/0/24": [
            {
                "host": "LABNCS51",
                "platform": "cisco NCS-540",
                "port": "TenGigE0/0/0/21",
                "ip": "10.250.1.38"
            }
        ],
        "TenGigE0/0/0/25": [
            {
                "host": "LABASR21.kfn.local",
                "platform": "cisco ASR-903",
                "port": "TenGigabitEthernet0/0/1",
                "ip": "10.250.1.41"
            }
        ],
        "TenGigE0/0/0/26": [
            {
                "host": "LABASR32.kfn.local",
                "platform": "cisco ASR-920-24SZ-M",
                "port": "TenGigabitEthernet0/0/27",
                "ip": "10.250.1.26"
            }
        ],
        "TenGigE0/0/0/27": [
            {
                "host": "LABASR31.kfn.local",
                "platform": "cisco ASR-920-24SZ-M",
                "port": "TenGigabitEthernet0/0/27",
                "ip": "10.250.1.22"
            }
        ],
        "MgmtEth0/RP0/CPU0/0": [
            {
                "host": "WICHLABSWI02.kfn.local",
                "platform": "cisco WS-C3560V2-24TS-SD",
                "port": "FastEthernet0/9",
                "ip": "192.168.100.6"
            }
        ]
[...]
}
```
IOS-XR 7.7.21 LNT CDP output:
```RP/0/RP0/CPU0:LABNCS61#show cdp neighbors detail
Mon Sep  9 12:30:43.733 CDT

-------------------------
Device ID: LABASR11
SysName : LABASR11
Entry address(es): 
  IPv4 address: 10.250.1.29
Platform: cisco ASR9K,  Capabilities: Router 
Interface: HundredGigE0/0/0/31
Port ID (outgoing port): HundredGigE0/3/0/0
Holdtime : 152 sec

Version :
 7.9.2

advertisement version: 2
Duplex: full

-------------------------
Device ID: LABASR34.kfn.local
SysName : 
Entry address(es): 
  IPv4 address: 10.250.1.102
Platform: cisco ASR-920-24SZ-M,  Capabilities: Router IGMP  Interface: TenGigE0/0/0/22
Port ID (outgoing port): TenGigabitEthernet0/0/27
Holdtime : 144 sec

Version :
Cisco IOS Software [Bengaluru], ASR920 Software (PPC_LINUX_IOSD-UNIVERSALK9_NPE-M), Version 17.6.3, RELEASE SOFTWARE (fc4) Technical Support: http://www.cisco.com/techsupport Copyright (c) 1986-2022 by Cisco Systems, Inc.
Compiled Wed 30-Mar-22 20:29 by mcpre

advertisement version: 2

-------------------------
[rest of output omitted for brevity]
```