### PR TITLE
Add support for local-preference operations in iosxr_route_maps

### DIFF
--- a/plugins/module_utils/network/iosxr/argspec/route_maps/route_maps.py
+++ b/plugins/module_utils/network/iosxr/argspec/route_maps/route_maps.py
@@ -89,6 +89,7 @@ class Route_mapsArgs(object):  # pylint: disable=R0903
                             "type": "dict",
                             "options": {
                                 "administrative_distance": {"type": "int"},
+                                "local-preference":{"type":"int"},
                                 "aigp_metric": {
                                     "type": "dict",
                                     "options": {
@@ -556,6 +557,7 @@ class Route_mapsArgs(object):  # pylint: disable=R0903
                             "type": "dict",
                             "options": {
                                 "administrative_distance": {"type": "int"},
+                                
                                 "aigp_metric": {
                                     "type": "dict",
                                     "options": {

--- a/plugins/module_utils/network/iosxr/argspec/route_maps/route_maps.py
+++ b/plugins/module_utils/network/iosxr/argspec/route_maps/route_maps.py
@@ -89,7 +89,7 @@ class Route_mapsArgs(object):  # pylint: disable=R0903
                             "type": "dict",
                             "options": {
                                 "administrative_distance": {"type": "int"},
-                                "local-preference":{"type":"int"},
+                                "local-preference": {"type": "int"},
                                 "aigp_metric": {
                                     "type": "dict",
                                     "options": {
@@ -557,7 +557,6 @@ class Route_mapsArgs(object):  # pylint: disable=R0903
                             "type": "dict",
                             "options": {
                                 "administrative_distance": {"type": "int"},
-                                
                                 "aigp_metric": {
                                     "type": "dict",
                                     "options": {

--- a/plugins/module_utils/network/iosxr/config/route_maps/route_maps.py
+++ b/plugins/module_utils/network/iosxr/config/route_maps/route_maps.py
@@ -55,6 +55,7 @@ class Route_maps(ResourceModule):
             "unsuppress_route",
             "remove",
             "set.administrative_distance",
+            "set.local_preference",
             "set.aigp_metric",
             "set.attribute_set",
             "set.c_multicast_routing",

--- a/plugins/module_utils/network/iosxr/rm_templates/route_maps.py
+++ b/plugins/module_utils/network/iosxr/rm_templates/route_maps.py
@@ -1166,7 +1166,7 @@ class Route_mapsTemplate(NetworkTemplate):
                 },
             },
         },
-        
+
         {
             "name": "set.local_preference",
             "getval": re.compile(
@@ -1184,7 +1184,7 @@ class Route_mapsTemplate(NetworkTemplate):
                 },
             },
         },
-        
-        
+
+
     ]
     # fmt: on

--- a/plugins/module_utils/network/iosxr/rm_templates/route_maps.py
+++ b/plugins/module_utils/network/iosxr/rm_templates/route_maps.py
@@ -1166,5 +1166,25 @@ class Route_mapsTemplate(NetworkTemplate):
                 },
             },
         },
+        
+        {
+            "name": "set.local_preference",
+            "getval": re.compile(
+                r"""
+                \s*set\slocal-preference
+                (\s(?P<value>\d+))
+                $""", re.VERBOSE,
+            ),
+            "setval": "set local-prefernce {{ set.local_preference|string }}",
+            "result": {
+                "policies": {
+                    "set": {
+                        "local-preference": "{{ value }}",
+                    },
+                },
+            },
+        },
+        
+        
     ]
     # fmt: on

--- a/tests/unit/modules/network/iosxr/test_iosxr_route_maps.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_route_maps.py
@@ -1276,3 +1276,37 @@ class TestIosxrRouteMapsModule(TestIosxrModule):
             },
         ]
         self.assertEqual(parsed_list, result["parsed"])
+
+    def test_aayush_iosxr_route_maps_parsed(self):
+        set_module_args(
+            dict(
+                running_config=dedent(
+                    """\
+                    route-policy APPLY_TEST_ROUTE_POLICY_COMPLEX
+                      set ospf-metric 232
+                      set local-preference 200
+                      prepend as-path most-recent 22
+                      
+                    end-policy
+                    """,
+                ),
+                state="parsed",
+            ),
+        )
+        result = self.execute_module(changed=False)
+        parsed_list = [
+            {
+                "name": "APPLY_TEST_ROUTE_POLICY_COMPLEX",
+                
+                "global": {
+                                "set": {
+                                    "ospf_metric": 232,
+                                    "local-preference": 200,
+                                    
+                                    
+                                },
+                            }
+                
+            },
+        ]
+        self.assertEqual(parsed_list, result["parsed"])

--- a/tests/unit/modules/network/iosxr/test_iosxr_route_maps.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_route_maps.py
@@ -1286,7 +1286,7 @@ class TestIosxrRouteMapsModule(TestIosxrModule):
                       set ospf-metric 232
                       set local-preference 200
                       prepend as-path most-recent 22
-                      
+
                     end-policy
                     """,
                 ),
@@ -1297,16 +1297,12 @@ class TestIosxrRouteMapsModule(TestIosxrModule):
         parsed_list = [
             {
                 "name": "APPLY_TEST_ROUTE_POLICY_COMPLEX",
-                
                 "global": {
-                                "set": {
-                                    "ospf_metric": 232,
-                                    "local-preference": 200,
-                                    
-                                    
-                                },
-                            }
-                
+                    "set": {
+                        "ospf_metric": 232,
+                        "local-preference": 200,
+                    },
+                },
             },
         ]
         self.assertEqual(parsed_list, result["parsed"])


### PR DESCRIPTION
##### SUMMARY
Enhancing set.local_preference in resource module to handle multiple local preference operations from box config. Modified to store operations (regular values, additions, multiplications) as a simple list instead of complex dictionaries to reduce redundancy and improve readability.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
iosxr_route_maps



