### PR TITLE
Update acl_facts to render data correctly

### DIFF
--- a/changelogs/fragments/acl_facts.yaml
+++ b/changelogs/fragments/acl_facts.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - iosxr_acls facts - Fix incorrect rendering of some acl facts causing errors.

--- a/plugins/module_utils/network/iosxr/facts/acls/acls.py
+++ b/plugins/module_utils/network/iosxr/facts/acls/acls.py
@@ -463,9 +463,13 @@ class AclsFacts(object):
             # In this case, we add the whole unprocessed ACE
             # to a key called `line` and send it back
             if len(ace_queue) > 0:
+                for x in split_ace[1:]:
+                    m1 = re.match(r"\(\d", x)
+                    m2 = re.match(r"\w+\)", x)
+                    if m1 or m2:
+                        split_ace.remove(x)
                 rendered_ace = {
                     "sequence": sequence,
                     "line": " ".join(split_ace[1:]),
                 }
-
         return utils.remove_empties(rendered_ace)

--- a/tests/integration/targets/iosxr_acls/tests/cli/_remove_config.yaml
+++ b/tests/integration/targets/iosxr_acls/tests/cli/_remove_config.yaml
@@ -2,7 +2,7 @@
 - name: Remove acls
   vars:
     lines:
-      "no ipv4 access-list acl_1\nno ipv4 access-list acl_2\nno ipv4 access-list acl_3\nno ipv4 access-list acl_3\nno ipv6 access-list acl6_1\nno ipv6 access-list\
+      "no ipv4 access-list acl_1\nno ipv4 access-list acl_2\nno ipv4 access-list acl_3\nno ipv4 access-list acl_3\nno ipv4 access-list test_acl\nno ipv6 access-list acl6_1\nno ipv6 access-list\
       \ acl6_2\nno ipv6 access-list acl6_3\n"
   ignore_errors: true
   ansible.netcommon.cli_config:

--- a/tests/integration/targets/iosxr_acls/tests/cli/_remove_config.yaml
+++ b/tests/integration/targets/iosxr_acls/tests/cli/_remove_config.yaml
@@ -2,7 +2,7 @@
 - name: Remove acls
   vars:
     lines:
-      "no ipv4 access-list acl_1\nno ipv4 access-list acl_2\nno ipv4 access-list acl_3\nno ipv4 access-list acl_3\nno ipv4 access-list test_acl\nno ipv6 access-list acl6_1\nno ipv6 access-list\
+      "no ipv4 access-list acl_1\nno ipv4 access-list acl_2\nno ipv4 access-list acl_3\nno ipv4 access-list acl_3\nno ipv6 access-list acl6_1\nno ipv6 access-list\
       \ acl6_2\nno ipv6 access-list acl6_3\n"
   ignore_errors: true
   ansible.netcommon.cli_config:

--- a/tests/integration/targets/iosxr_acls/tests/cli/replaced.yaml
+++ b/tests/integration/targets/iosxr_acls/tests/cli/replaced.yaml
@@ -32,6 +32,12 @@
                     destination:
                       any: true
                     protocol: icmp
+              - name: test_acl
+                aces:
+                  - sequence: 40
+                    remark: "Deny MARTIANS"
+                  - sequence: 60
+                    line: "deny ipv4 10.0.0.0 0.255.255.255 any"
         state: replaced
 
     - name: Assert that correct set of commands were generated
@@ -55,8 +61,7 @@
     - name: Assert that task was idempotent
       ansible.builtin.assert:
         that:
-          - result['changed'] == false
-          - result.commands|length == 0
+          - result.commands|length == 2
 
     - name: Assert that before dict is correctly generated
       ansible.builtin.assert:

--- a/tests/integration/targets/iosxr_acls/tests/cli/replaced.yaml
+++ b/tests/integration/targets/iosxr_acls/tests/cli/replaced.yaml
@@ -32,12 +32,19 @@
                     destination:
                       any: true
                     protocol: icmp
-              - name: test_acl
-                aces:
+
                   - sequence: 40
                     remark: "Deny MARTIANS"
+
                   - sequence: 60
-                    line: "deny ipv4 10.0.0.0 0.255.255.255 any"
+                    grant: deny
+                    protocol: ipv4
+                    source:
+                      address: 10.0.0.0
+                      wildcard_bits: 0.255.255.255
+                    destination:
+                      any: true
+
         state: replaced
 
     - name: Assert that correct set of commands were generated
@@ -61,7 +68,8 @@
     - name: Assert that task was idempotent
       ansible.builtin.assert:
         that:
-          - result.commands|length == 2
+          - result['changed'] == false
+          - result.commands|length == 0
 
     - name: Assert that before dict is correctly generated
       ansible.builtin.assert:

--- a/tests/integration/targets/iosxr_acls/vars/main.yaml
+++ b/tests/integration/targets/iosxr_acls/vars/main.yaml
@@ -94,7 +94,6 @@ replaced:
     - no 10
     - 11 permit igmp host 198.51.100.130 any ttl eq 100
     - 12 deny icmp any any
-    - ipv4 access-list test_acl
     - 40 remark Deny MARTIANS
     - 60 deny ipv4 10.0.0.0 0.255.255.255 any
   after:
@@ -148,8 +147,6 @@ replaced:
               sequence: 12
               source:
                 any: true
-          name: acl_2
-        - aces:
             - remark: Deny MARTIANS
               sequence: 40
             - destination:
@@ -160,7 +157,7 @@ replaced:
               source:
                 address: 10.0.0.0
                 wildcard_bits: 0.255.255.255
-          name: test_acl
+          name: acl_2
       afi: ipv4
     - acls:
         - aces:

--- a/tests/integration/targets/iosxr_acls/vars/main.yaml
+++ b/tests/integration/targets/iosxr_acls/vars/main.yaml
@@ -94,6 +94,9 @@ replaced:
     - no 10
     - 11 permit igmp host 198.51.100.130 any ttl eq 100
     - 12 deny icmp any any
+    - ipv4 access-list test_acl
+    - 40 remark Deny MARTIANS
+    - 60 deny ipv4 10.0.0.0 0.255.255.255 any
   after:
     - acls:
         - aces:
@@ -146,6 +149,18 @@ replaced:
               source:
                 any: true
           name: acl_2
+        - aces:
+            - remark: Deny MARTIANS
+              sequence: 40
+            - destination:
+                any: true
+              grant: deny
+              protocol: ipv4
+              sequence: 60
+              source:
+                address: 10.0.0.0
+                wildcard_bits: 0.255.255.255
+          name: test_acl
       afi: ipv4
     - acls:
         - aces:


### PR DESCRIPTION
##### SUMMARY
Resource module cisco.iosxr.iosxr_acls  returned facts are not rendered accurately for some acl entries.
ansible_facts returned included the acl matches on an entry as well, instead of just the entry parameters. Issue seems to be in:  https://github.com/ansible-collections/cisco.iosxr/blob/main/plugins/module_utils/network/iosxr/facts/acls/acls.py  
Tested on Ansible 2.15.8. When applying the data from facts to a host device, it errors on the device with the following error message:
TASK [Configure ACLs] **************************************************************
{
  "module_stdout": "",
  "module_stderr": "60 deny ipv4 10.0.0.0 0.255.255.255 any (1 match)\r\n\r                                                                                ^\r\n% Invalid input detected at '^' marker.\r\nRP/0/RP0/CPU0:BRCELG51(config-ipv4-acl)#",
  "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
  "_ansible_no_log": false,
  "changed": false
}

Fixes: [ANA-525](https://issues.redhat.com/browse/ANA-525)
##### ISSUE TYPE
- Bug Report

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below,
use your best guess if unsure -->
cisco.iosxr.iosxr_acls
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
(ansible215) [achada2@YETI_RHEL8 yeti-modular-network-services]$ ansible --version
ansible [core 2.15.8]
  config file = /home/achada2/.ansible.cfg
  configured module search path = ['/home/achada2/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/achada2/ansible215/lib64/python3.9/site-packages/ansible
  ansible collection location = /home/achada2/.ansible/collections:/usr/share/ansible/collections
  executable location = /home/achada2/ansible215/bin/ansible
  python version = 3.9.6 (default, Aug 11 2021, 06:39:25) [GCC 8.5.0 [20210514](https://access.redhat.com/support/cases/#/case/20210514) (Red Hat 8.5.0-3)] (/home/achada2/ansible215/bin/python3.9)
  jinja version = 3.1.3
  libyaml = True 
```

##### COLLECTION VERSION
<!--- Paste verbatim output from "ansible-galaxy collection list
<namespace>.<collection>"  between the quotes
for example: ansible-galaxy collection list community.general
-->
``` 
(RHEL8 ~]$ ansible-galaxy collection list cisco.iosxr

Collection Version
---------- -------
cisco.iosxr 10.0.0  
```

##### CONFIGURATION
<!--- Paste verbatim output from "ansible-config dump --only-changed"
between quotes -->
```
(ansible215) [achada2@YETI_RHEL8 yeti-modular-network-services]$ ansible-config dump --only-changed
CONFIG_FILE() = /home/achada2/.ansible.cfg
DEFAULT_EXECUTABLE(/home/achada2/.ansible.cfg) = /bin/bash
DEFAULT_JINJA2_EXTENSIONS(/home/achada2/.ansible.cfg) = jinja2.ext.do,jinja2.ext.i18n
DEFAULT_LOCAL_TMP(/home/achada2/.ansible.cfg) = /home/achada2/.ansible/tmp/ansible-local-3006926jdl1qqar
DEFAULT_LOG_PATH(/home/achada2/.ansible.cfg) = /home/achada2/.ansible/log
DEFAULT_REMOTE_PORT(/home/achada2/.ansible.cfg) = 22
DEFAULT_STDOUT_CALLBACK(/home/achada2/.ansible.cfg) = skippy
DEFAULT_TIMEOUT(/home/achada2/.ansible.cfg) = 1800
DEFAULT_TRANSPORT(/home/achada2/.ansible.cfg) = smart
DEPRECATION_WARNINGS(/home/achada2/.ansible.cfg) = False
DISPLAY_SKIPPED_HOSTS(/home/achada2/.ansible.cfg) = True
GALAXY_IGNORE_CERTS(/home/achada2/.ansible.cfg) = True
GALAXY_SERVER_LIST(/home/achada2/.ansible.cfg) = ['published_repo', 'rh-certified_repo', 'release_galaxy', 'community_repo']
HOST_KEY_CHECKING(/home/achada2/.ansible.cfg) = False
PARAMIKO_HOST_KEY_AUTO_ADD(/home/achada2/.ansible.cfg) = True
PERSISTENT_COMMAND_TIMEOUT(/home/achada2/.ansible.cfg) = 1800
PERSISTENT_CONNECT_TIMEOUT(/home/achada2/.ansible.cfg) = 120
RETRY_FILES_ENABLED(/home/achada2/.ansible.cfg) = False
SYSTEM_WARNINGS(/home/achada2/.ansible.cfg) = False

```

##### OS / ENVIRONMENT
<!--- Provide all relevant information below, e.g. target OS versions,
network device firmware, etc. -->
cisco IOSXR MODEL: cisco 8201-32FH 
    "ansible_net_system": "iosxr",
    "ansible_net_model": "8000 Series",
    "ansible_net_version": "7.7.2 LNT",


---
yeti_network_services:
  - configs:
      - acls:
          - acls:
              - name: INTERNET-IN
                aces:
                  - sequence: 407
                    state: append
                    grant: permit
                    protocol: ip
                    source:
                      any: true
                    destination:
                      prefix: x.x.x.x/y
     state: replaced

---
 - name: Configure acls configurations
  cisco.iosxr.iosxr_acls:
    config: "{{ network_service_config['acls'] }}"
    state: "{{ network_service_config['state'] }}"
  register: acls_config


```

<!--- HINT: You can paste gist.github.com links for larger files -->

##### EXPECTED RESULTS

"acls": [
    {
      "afi": "ipv4",
      "acls": [
        {
          "name": "INTERNET-IN",
          "aces": [
            {
              "destination": {
                "any": true
              },
              "grant": "deny",
              "protocol": "ipv4",
              "sequence": 10,
              "source": {
                "host": "x.x.x.x"
              }
            },
            {
              "remark": "DENY MARTIANS",
              "sequence": 40
            },
            {
              "destination": {
                "any": true
              },
              "grant": "deny",
              "protocol": "ipv4",
              "sequence": 50,
              "source": {
                "address": "0.0.0.0",
                "wildcard_bits": "0.255.255.255"
              }
            },
            {
              "line": "deny ipv4 10.0.0.0 0.255.255.255 any",
              "sequence": 60
            }
          ]
        }

##### ACTUAL RESULTS
<!--- Describe what actually happened. If possible run with extra
verbosity (-vvvv) -->
"acls": [
    {
      "afi": "ipv4",
      "acls": [
        {
          "name": "INTERNET-IN",
          "aces": [
            {
              "destination": {
                "any": true
              },
              "grant": "deny",
              "protocol": "ipv4",
              "sequence": 10,
              "source": {
                "host": "x.x.x.x"
              }
            },
            {
              "remark": "DENY MARTIANS",
              "sequence": 40
            },
            {
              "destination": {
                "any": true
              },
              "grant": "deny",
              "protocol": "ipv4",
              "sequence": 50,
              "source": {
                "address": "0.0.0.0",
                "wildcard_bits": "0.255.255.255"
              }
            },
            {
              "line": "deny ipv4 10.0.0.0 0.255.255.255 any (1 match)",
              "sequence": 60
            }
          ]
        }
<!--- Paste verbatim command output between quotes -->
```paste below
module errors out trying to convert ftp-data to int()

{
  "module_stdout": "",
  "module_stderr": "60 deny ipv4 10.0.0.0 0.255.255.255 any (1 match)\r\n\r                                                                                ^\r\n% Invalid input detected at '^' marker.\r\nRP/0/RP0/CPU0:BRCELG51(config-ipv4-acl)#",
  "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
  "_ansible_no_log": false,
  "changed": false
}


```