### PR TITLE
Update the iosxr_banner module to allow exec banner configuration on IOS-XR devices

### DIFF
--- a/plugins/modules/iosxr_banner.py
+++ b/plugins/modules/iosxr_banner.py
@@ -255,7 +255,7 @@ class NCConfiguration(ConfigBase):
 def main():
     """main entry point for module execution"""
     argument_spec = dict(
-        banner=dict(required=True, choices=["login", "motd"]),
+        banner=dict(required=True, choices=["login", "motd", "exec"]),
         text=dict(),
         state=dict(default="present", choices=["present", "absent"]),
     )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update the iosxr_banner module to allow exec banner configuration on IOS-XR devices
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
iosxr_banner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
It appears that updating the array in the choices function to include the 'exec' string allows this to work as expected. The 'exec' option can then be passed to the banner parameter in the module without issue. This has been tested locally against ASR9K/NCS routers.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
