### PR TITLE
Fix route map if/else

### DIFF
--- a/changelogs/fragments/route_map.yml
+++ b/changelogs/fragments/route_map.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fixes route map fact gathering to correctly gather facts with a elif condition.

--- a/plugins/module_utils/network/iosxr/facts/route_maps/route_maps.py
+++ b/plugins/module_utils/network/iosxr/facts/route_maps/route_maps.py
@@ -187,9 +187,10 @@ class Route_mapsFacts(object):
                         if cond_type != "global":
                             policy_route[cond_type]["condition"] = actual_cond
                 elif cond_type == "elseif_section":
-                    if_elif_data.update(objs[0])
-                    if_elif_data["condition"] = actual_cond
-                    if_elif.append(if_elif_data)
+                    if objs:
+                        if_elif_data.update(objs[0])
+                        if_elif_data["condition"] = actual_cond
+                        if_elif.append(if_elif_data)
                 elif cond_type == "else_section":
                     else_data = else_resolve_policy_data(policy)
 

--- a/tests/integration/targets/iosxr_route_maps/tests/common/empty_elseif.yaml
+++ b/tests/integration/targets/iosxr_route_maps/tests/common/empty_elseif.yaml
@@ -1,0 +1,55 @@
+---
+- ansible.builtin.debug:
+    msg: START iosxr_route_maps empty_elseif integration tests on connection={{ ansible_connection }}
+
+- ansible.builtin.include_tasks: _remove_config.yaml
+
+- block:
+    - name: Create route policy with empty elseif section
+      register: result
+      cisco.iosxr.iosxr_route_maps:
+        state: merged
+        config:
+          - name: TEST_EMPTY_ELSEIF
+            if_section:
+              condition: destination in DEFAULT
+              set:
+                qos_group: 2
+            elseif_section:
+              - condition: destination in TEST-EMPTY
+            else_section:
+              set:
+                ospf_metric: 232
+
+    - name: Assert that correct set of commands were generated
+      ansible.builtin.assert:
+        that:
+          - result.changed == true
+          - "'route-policy TEST_EMPTY_ELSEIF' in result.commands"
+          - "'if destination in DEFAULT then' in result.commands"
+          - "'set qos-group 2' in result.commands"
+          - "'elseif destination in TEST-EMPTY then' in result.commands"
+          - "'else' in result.commands"
+          - "'set ospf-metric 232' in result.commands"
+          - "'endif' in result.commands"
+          - "'end-policy' in result.commands"
+
+    - name: Verify the route policy was created correctly
+      register: verify
+      cisco.iosxr.iosxr_route_maps:
+        state: gathered
+
+    - name: Assert that the route policy exists with correct structure
+      ansible.builtin.assert:
+        that:
+          - verify.gathered is defined
+          - verify.gathered|length > 0
+          - verify.gathered|selectattr('name', 'equalto', 'TEST_EMPTY_ELSEIF')|list|length == 1
+          - verify.gathered|selectattr('name', 'equalto', 'TEST_EMPTY_ELSEIF')|first.if_section.condition == "destination in DEFAULT"
+          - verify.gathered|selectattr('name', 'equalto', 'TEST_EMPTY_ELSEIF')|first.if_section.set.qos_group == 2
+          - verify.gathered|selectattr('name', 'equalto', 'TEST_EMPTY_ELSEIF')|first.elseif_section|length == 1
+          - verify.gathered|selectattr('name', 'equalto', 'TEST_EMPTY_ELSEIF')|first.elseif_section[0].condition == "destination in TEST-EMPTY"
+          - verify.gathered|selectattr('name', 'equalto', 'TEST_EMPTY_ELSEIF')|first.else_section.set.ospf_metric == 232
+
+  always:
+    - ansible.builtin.include_tasks: _remove_config.yaml


### PR DESCRIPTION
##### SUMMARY
cisco iosxr_route_maps resource module fails to return facts with an error "list index out of range ".
 Issue appears to be in the facts module utility in method  rec_resolve_policy_data() that needs a condition  if objs is defined.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
Liniking case #04095628

******************************
ansible-playbook [core 2.15.8]
python version = 3.9.6 
# /home/user/.ansible/collections/ansible_collections
Collection                    Version
----------------------------- -------
cisco.iosxr                   10.3.0 
********************************

PLAYBOOK: route_policies_parsed.yml ***************************************************************************************************************************************************************************************************************
1 plays in route_policies_parsed.yml

PLAY [all] ****************************************************************************************************************************************************************************************************************************************

TASK [Parse the provided configuration] ***********************************************************************************************************************************************************************************************************
task path: /home/achada2/sips_automation/Adi_Local_Testing_PBs/route_policies_parsed.yml:11
The full traceback is:
  File "/home/achada2/.ansible/collections/ansible_collections/ansible/netcommon/plugins/module_utils/network/common/facts/facts.py", line 128, in get_network_resources_facts
    inst.populate_facts(self._connection, self.ansible_facts, data)
