### PR TITLE
Fixes RM template related issues in route_maps

### DIFF
--- a/changelogs/fragments/fix_route_maps.yml
+++ b/changelogs/fragments/fix_route_maps.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - iosxr_route_maps - Fix issue where wrong commands were being generated for several attributes.

--- a/plugins/module_utils/network/iosxr/rm_templates/route_maps.py
+++ b/plugins/module_utils/network/iosxr/rm_templates/route_maps.py
@@ -148,7 +148,7 @@ class Route_mapsTemplate(NetworkTemplate):
             "setval": "prepend"
             "{{ (' as-path ' + prepend.as_path|string) if prepend.as_path is defined else '' }}"
             "{{ (' most-recent') if prepend.most_recent is defined else '' }}"
-            "{{ (' own-as') if prepend.own_as|d(False) is defined else '' }}"
+            "{{ (' own-as') if prepend.own_as|d(False) else '' }}"
             "{{ (' ' + prepend.number_of_times|string) if prepend.number_of_times is defined else '' }}",
             "result": {
                 "policies": {
@@ -199,8 +199,8 @@ class Route_mapsTemplate(NetworkTemplate):
                 $""", re.VERBOSE,
             ),
             "setval": "remove as-path"
-            "{{ (' private-as' ) if remove.set|d(False) is defined else '' }}"
-            "{{ (' entire-aspath' ) if remove.entire_aspath|d(False) is defined else '' }}",
+            "{{ (' private-as' ) if remove.set|d(False) else '' }}"
+            "{{ (' entire-aspath' ) if remove.entire_aspath|d(False) else '' }}",
             "result": {
                 "policies": {
                     "remove": {
@@ -242,7 +242,7 @@ class Route_mapsTemplate(NetworkTemplate):
             "{{ ' *' if pref.multiply|d(False) else '' }}"
             "{{ ' +' if pref.increment|d(False) else '' }}"
             "{{ ' -' if pref.decrement|d(False) else '' }}"
-            "{{ pref.metric_number|string }}\n"
+            "{{ ' ' ~ pref.metric_number|string }}\n"
             "{% endfor %}",
             "result": {
                 "policies": {
@@ -864,9 +864,9 @@ class Route_mapsTemplate(NetworkTemplate):
                 $""", re.VERBOSE,
             ),
             "setval": "set path-selection backup"
-            "{{ (' ' + rib-metric-as-external|string ) if set.path_selection.backup.backup_decimal is defined else '' }}"
-            "{{ (' advertise' ) if set.path_selection.backup.advertise|d(False) is defined else '' }}"
-            "{{ (' install' ) if set.path_selection.backup.install|d(False) is defined else '' }}",
+            "{{ (' ' + set.path_selection.backup.backup_decimal|string ) if set.path_selection.backup.backup_decimal is defined else '' }}"
+            "{{ (' advertise') if set.path_selection.backup.advertise|d(False) else '' }}"
+            "{{ (' install') if set.path_selection.backup.install|d(False) else '' }}",
             "result": {
                 "policies": {
                     "set": {

--- a/tests/unit/modules/network/iosxr/test_iosxr_route_maps.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_route_maps.py
@@ -1390,4 +1390,4 @@ class TestIosxrRouteMapsModule(TestIosxrModule):
             "endif",
             "end-policy",
         ]
-        self.assertEqual(sorted(result["commands"]), sorted(commands))
+        self.assertEqual(result["commands"], commands)

--- a/tests/unit/modules/network/iosxr/test_iosxr_route_maps.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_route_maps.py
@@ -1322,7 +1322,6 @@ class TestIosxrRouteMapsModule(TestIosxrModule):
         self.get_config_data.return_value = dedent(
             """\
             route-policy TEST_ROUTE_POLICY_COMPLEX
-
             """,
         )
         set_module_args(
@@ -1331,8 +1330,13 @@ class TestIosxrRouteMapsModule(TestIosxrModule):
                     {
                         "global": {
                             "set": {
-                                "path_selection": {"backup": {"backup_decimal": 1, "install": True}}
-                            }
+                                "path_selection": {
+                                    "backup": {
+                                        "backup_decimal": 1,
+                                        "install": True,
+                                    },
+                                },
+                            },
                         },
                         "if_section": {
                             "condition": "destination in DEFAULT",

--- a/tests/unit/modules/network/iosxr/test_iosxr_route_maps.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_route_maps.py
@@ -1329,7 +1329,11 @@ class TestIosxrRouteMapsModule(TestIosxrModule):
             dict(
                 config=[
                     {
-                        "global": {"set": {"path_selection": {"backup": {"backup_decimal": 1, "install": True}}}},
+                        "global": {
+                            "set": {
+                                "path_selection": {"backup": {"backup_decimal": 1, "install": True}}
+                            }
+                        },
                         "if_section": {
                             "condition": "destination in DEFAULT",
                             "set": {
@@ -1340,24 +1344,24 @@ class TestIosxrRouteMapsModule(TestIosxrModule):
                             {
                                 "condition": "destination in ALL-UE-POOLS-V6 and med le 100",
                                 "set": {
-                                    "weight": 100
+                                    "weight": 100,
                                 },
                                 "prepend": {
                                     "as_path": 10728,
-                                }
+                                },
                             },
                             {
                                 "condition": "as-path in COLO-PEER",
                                 "pass": True,
                                 "remove": {
-                                    "set": True
-                                }
-                            }
+                                    "set": True,
+                                },
+                            },
                         ],
                         "else_section": {
                             "global": {
-                                "drop": True
-                            }
+                                "drop": True,
+                            },
                         },
                         "name": "APPLY_TEST_ROUTE_POLICY_COMPLEX",
                     },
@@ -1367,19 +1371,19 @@ class TestIosxrRouteMapsModule(TestIosxrModule):
         )
         result = self.execute_module(changed=True)
         commands = [
-            'route-policy APPLY_TEST_ROUTE_POLICY_COMPLEX', 
-            'set path-selection backup 1 install', 
-            'if destination in DEFAULT then', 
-            'set weight 100', 
-            'elseif destination in ALL-UE-POOLS-V6 and med le 100 then', 
-            'prepend as-path 10728', 
-            'set weight 100', 
-            'elseif as-path in COLO-PEER then', 
-            'pass', 
-            'remove as-path private-as', 
-            'else', 
-            'drop', 
-            'endif', 
-            'end-policy'
+            "route-policy APPLY_TEST_ROUTE_POLICY_COMPLEX",
+            "set path-selection backup 1 install",
+            "if destination in DEFAULT then",
+            "set weight 100",
+            "elseif destination in ALL-UE-POOLS-V6 and med le 100 then",
+            "prepend as-path 10728",
+            "set weight 100",
+            "elseif as-path in COLO-PEER then",
+            "pass",
+            "remove as-path private-as",
+            "else",
+            "drop",
+            "endif",
+            "end-policy",
         ]
         self.assertEqual(sorted(result["commands"]), sorted(commands))


### PR DESCRIPTION
##### SUMMARY

1. Backup Command Not Applied: The customer is unable to use the `set.path_selection.backup` command, even though it appears to be invoked correctly. No command is being added during execution. 

2. Improper Spacing with `local-preference`: When a value is added to `local-preference`, the spacing is incorrect. eg: `set local-preference100`

3. Incorrect prepend as-path Command: prepend as-path command receives no arguments during execution, yet the arguments are included in the final command.eg: `prepend as-path 10728 own-as 3`

4. Incorrect remove as-path Command: The remove as-path command receives no arguments, but entire-aspath is added unexpectedly. eg: `remove as-path entire-aspath`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- iosxr_route_maps

#### Solution

Have modified the rm_templates which was causing this issue, was happening due to mistyped set-vals
