### PR TITLE
[RFE] Add missing set attributes med and extcommunty in route_maps

### DIFF
--- a/changelogs/fragments/route_maps_set_attrs.yaml
+++ b/changelogs/fragments/route_maps_set_attrs.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "Adds support for missing set route map attributes med and extcommunity"

--- a/plugins/module_utils/network/iosxr/argspec/route_maps/route_maps.py
+++ b/plugins/module_utils/network/iosxr/argspec/route_maps/route_maps.py
@@ -176,6 +176,19 @@ class Route_mapsArgs(object):  # pylint: disable=R0903
                                         "max_transmission": {"type": "int"},
                                     },
                                 },
+                                "extcommunity": {
+                                    "type": "dict",
+                                    "options": {
+                                        "soo": {"type": "str"},
+                                        "rt": {"type": "str"},
+                                        "additive": {"type": "bool"},
+                                        "bandwidth": {"type": "str"},
+                                        "color": {"type": "str"},
+                                        "cost": {"type": "str"},
+                                        "redirect_to_rt": {"type": "str"},
+                                        "seg_nh": {"type": "str"},
+                                    },
+                                },
                                 "fallback_vrf_lookup": {"type": "bool"},
                                 "flow_tag": {"type": "int"},
                                 "forward_class": {"type": "int"},
@@ -202,6 +215,17 @@ class Route_mapsArgs(object):  # pylint: disable=R0903
                                 },
                                 "load_balance": {"type": "bool"},
                                 "lsm_root": {"type": "str"},
+                                "med": {
+                                    "type": "dict",
+                                    "options": {
+                                        "value": {"type": "int"},
+                                        "increment": {"type": "int"},
+                                        "decrement": {"type": "int"},
+                                        "igp_cost": {"type": "bool"},
+                                        "max_reachable": {"type": "bool"},
+                                        "parameter": {"type": "str"},  # like "$param1"
+                                    },
+                                },
                                 "metric_type": {
                                     "type": "dict",
                                     "options": {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds missing set attributes 
- set med
- set extcommunity
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- fixes issue - [ANA-732](https://issues.redhat.com/browse/ANA-732)
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`iosxr_route_maps`

