### PR TITLE
Fix downstream upstream related tests with CML

### DIFF
--- a/changelogs/fragments/fix_tests.yaml
+++ b/changelogs/fragments/fix_tests.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Fixes downstream related tests on CML

--- a/tests/integration/targets/iosxr_interfaces/tests/cli/_populate_config.yaml
+++ b/tests/integration/targets/iosxr_interfaces/tests/cli/_populate_config.yaml
@@ -4,7 +4,7 @@
     lines:
       - "description this is interface0"
       - "mtu 65"
-      - "speed 10"
+      # - "speed 10" # Not supported in CML Version of XR
       - "shutdown"
     parents: "interface GigabitEthernet 0/0/0/0"
 
@@ -13,6 +13,6 @@
     lines:
       - "description this is interface1"
       - "mtu 65"
-      - "speed 10"
+      # - "speed 10" # Not supported in CML Version of XR
       - "no shutdown"
     parents: "interface GigabitEthernet 0/0/0/1"

--- a/tests/integration/targets/iosxr_interfaces/tests/cli/gathered.yaml
+++ b/tests/integration/targets/iosxr_interfaces/tests/cli/gathered.yaml
@@ -15,14 +15,11 @@
             description: This interface is Configured and Merged by Ansible-Network
             mtu: 110
             enabled: true
-            duplex: half
 
           - name: GigabitEthernet0/0/0/1
             description: Configured and Merged by Ansible-Network
             mtu: 2800
             enabled: false
-            speed: 100
-            duplex: full
         state: merged
 
     - name: Gather interfaces facts using gathered state

--- a/tests/integration/targets/iosxr_interfaces/tests/cli/merged.yaml
+++ b/tests/integration/targets/iosxr_interfaces/tests/cli/merged.yaml
@@ -14,14 +14,11 @@
           - name: GigabitEthernet0/0/0/0
             description: Configured and Merged by Ansible-Network
             mtu: 110
-            duplex: half
 
           - name: GigabitEthernet0/0/0/1
             description: Configured and Merged by Ansible-Network
             mtu: 2800
             enabled: false
-            speed: 100
-            duplex: full
         state: merged
 
     - name: Assert that correct set of commands were generated
@@ -62,14 +59,11 @@
             description: Configured and Merged by Ansible-Network
             mtu: 110
             enabled: true
-            duplex: half
 
           - name: GigabitEthernet0/0/0/3
             description: Configured and Merged by Ansible-Network
             mtu: 2800
             enabled: false
-            speed: 100
-            duplex: full
         state: merged
 
     - name: Assert that correct set of commands were generated

--- a/tests/integration/targets/iosxr_interfaces/tests/cli/rendered.yaml
+++ b/tests/integration/targets/iosxr_interfaces/tests/cli/rendered.yaml
@@ -16,7 +16,7 @@
         description: Configured and Merged by Ansible-Network
         mtu: 2800
         enabled: false
-        speed: 100
+        # speed: 100 # Not supported in CML Version of XR
         duplex: full
     state: rendered
 

--- a/tests/integration/targets/iosxr_interfaces/tests/cli/replaced.yaml
+++ b/tests/integration/targets/iosxr_interfaces/tests/cli/replaced.yaml
@@ -17,7 +17,6 @@
 
           - name: GigabitEthernet0/0/0/1
             description: Configured and Replaced by Ansible-Network
-            speed: 100
         state: replaced
 
     - name: Assert that correct set of commands were generated

--- a/tests/integration/targets/iosxr_interfaces/vars/main.yaml
+++ b/tests/integration/targets/iosxr_interfaces/vars/main.yaml
@@ -11,22 +11,17 @@ merged:
       enabled: false
       mtu: 65
       name: GigabitEthernet0/0/0/0
-      speed: 10
     - description: this is interface1
       enabled: true
       mtu: 65
       name: GigabitEthernet0/0/0/1
-      speed: 10
   commands:
     - interface GigabitEthernet0/0/0/0
     - description Configured and Merged by Ansible-Network
     - mtu 110
-    - duplex half
     - interface GigabitEthernet0/0/0/1
     - description Configured and Merged by Ansible-Network
     - mtu 2800
-    - speed 100
-    - duplex full
     - shutdown
   after:
     - enabled: true
@@ -36,17 +31,13 @@ merged:
     - enabled: true
       name: MgmtEth0/RP0/CPU0/0
     - description: Configured and Merged by Ansible-Network
-      duplex: half
       enabled: false
       mtu: 110
       name: GigabitEthernet0/0/0/0
-      speed: 10
     - description: Configured and Merged by Ansible-Network
-      duplex: full
       enabled: false
       mtu: 2800
       name: GigabitEthernet0/0/0/1
-      speed: 100
   preconfigure:
     before:
       - enabled: true
@@ -59,13 +50,10 @@ merged:
       - interface GigabitEthernet0/0/0/2
       - description Configured and Merged by Ansible-Network
       - mtu 110
-      - duplex half
       - no shutdown
       - interface GigabitEthernet0/0/0/3
       - description Configured and Merged by Ansible-Network
       - mtu 2800
-      - speed 100
-      - duplex full
       - shutdown
     after:
       - enabled: true
@@ -75,15 +63,12 @@ merged:
       - enabled: true
         name: MgmtEth0/RP0/CPU0/0
       - description: Configured and Merged by Ansible-Network
-        duplex: half
         enabled: true
         mtu: 110
         name: GigabitEthernet0/0/0/2
       - description: Configured and Merged by Ansible-Network
-        duplex: full
         enabled: false
         mtu: 2800
-        speed: 100
         name: GigabitEthernet0/0/0/3
 
 parsed:
@@ -114,21 +99,19 @@ replaced:
       enabled: false
       mtu: 65
       name: GigabitEthernet0/0/0/0
-      speed: 10
+      # speed: 10
     - description: this is interface1
       enabled: true
       mtu: 65
       name: GigabitEthernet0/0/0/1
-      speed: 10
+      # speed: 10
   commands:
     - interface GigabitEthernet0/0/0/0
-    - no speed
     - description Configured and Replaced by Ansible-Network
     - mtu 110
     - interface GigabitEthernet0/0/0/1
     - no mtu
     - description Configured and Replaced by Ansible-Network
-    - speed 100
   after:
     - enabled: true
       name: Loopback888
@@ -143,7 +126,6 @@ replaced:
     - description: Configured and Replaced by Ansible-Network
       enabled: true
       name: GigabitEthernet0/0/0/1
-      speed: 100
 rendered:
   commands:
     - interface GigabitEthernet0/0/0/0
@@ -154,7 +136,6 @@ rendered:
     - interface GigabitEthernet0/0/0/1
     - description Configured and Merged by Ansible-Network
     - mtu 2800
-    - speed 100
     - duplex full
     - shutdown
 overridden:
@@ -169,12 +150,10 @@ overridden:
       enabled: false
       mtu: 65
       name: GigabitEthernet0/0/0/0
-      speed: 10
     - description: this is interface1
       enabled: true
       mtu: 65
       name: GigabitEthernet0/0/0/1
-      speed: 10
   commands:
     - interface GigabitEthernet0/0/0/0
     - no description
@@ -184,7 +163,6 @@ overridden:
     - description Configured and Overridden by Ansible-Network
     - mtu 2000
     - duplex full
-    - speed 100
     - shutdown
   after:
     - enabled: true
@@ -198,7 +176,6 @@ overridden:
       enabled: false
       mtu: 2000
       name: GigabitEthernet0/0/0/1
-      speed: 100
 gathered:
   after:
     - enabled: true
@@ -208,17 +185,13 @@ gathered:
     - enabled: true
       name: MgmtEth0/RP0/CPU0/0
     - description: This interface is Configured and Merged by Ansible-Network
-      duplex: half
       enabled: true
       mtu: 110
       name: GigabitEthernet0/0/0/0
-      speed: 10
     - description: Configured and Merged by Ansible-Network
-      duplex: full
       enabled: false
       mtu: 2800
       name: GigabitEthernet0/0/0/1
-      speed: 100
 deleted:
   before:
     - enabled: true
@@ -231,12 +204,12 @@ deleted:
       enabled: false
       mtu: 65
       name: GigabitEthernet0/0/0/0
-      speed: 10
+      # speed: 10
     - description: this is interface1
       enabled: true
       mtu: 65
       name: GigabitEthernet0/0/0/1
-      speed: 10
+      # speed: 10
   commands:
     - interface GigabitEthernet0/0/0/0
     - no description

--- a/tests/integration/targets/iosxr_l2_interfaces/tests/cli/_populate_config.yaml
+++ b/tests/integration/targets/iosxr_l2_interfaces/tests/cli/_populate_config.yaml
@@ -1,8 +1,19 @@
 ---
-- name: Populate configuration
-  vars:
+- name: Configure interface GigabitEthernet 0/0/0/1
+  cisco.iosxr.iosxr_config:
     lines:
-      "interface GigabitEthernet 0/0/0/1\nl2transport l2protocol cpsv tunnel\nl2transport propagate remote-status\ninterface GigabitEthernet 0/0/0/4\nl2transport\
-      \ l2protocol cpsv tunnel\ninterface GigabitEthernet 0/0/0/3.900\nencapsulation dot1q 40 second-dot1q 60\n"
-  ansible.netcommon.cli_config:
-    config: "{{ lines }}"
+      - l2transport l2protocol cpsv tunnel
+      - l2transport propagate remote-status
+    parents: interface GigabitEthernet 0/0/0/1
+
+- name: Configure interface GigabitEthernet 0/0/0/4
+  cisco.iosxr.iosxr_config:
+    lines:
+      - l2transport l2protocol cpsv tunnel
+    parents: interface GigabitEthernet 0/0/0/4
+
+- name: Configure interface GigabitEthernet 0/0/0/3.900
+  cisco.iosxr.iosxr_config:
+    lines:
+      - encapsulation dot1q 40 second-dot1q 60
+    parents: interface GigabitEthernet 0/0/0/3.900

--- a/tests/integration/targets/iosxr_lacp_interfaces/tests/cli/_populate.yaml
+++ b/tests/integration/targets/iosxr_lacp_interfaces/tests/cli/_populate.yaml
@@ -16,7 +16,7 @@
 - name: Setup gige0
   cisco.iosxr.iosxr_config:
     lines:
-      - lacp period 100
+      - lacp period 300
     parents: interface GigabitEthernet0/0/0/0
 
 - name: Setup gige1

--- a/tests/integration/targets/iosxr_lacp_interfaces/vars/main.yaml
+++ b/tests/integration/targets/iosxr_lacp_interfaces/vars/main.yaml
@@ -32,7 +32,7 @@ populate:
     system:
       mac: 00c2.4c00.bd15
   - name: GigabitEthernet0/0/0/0
-    period: 100
+    period: 300
   - name: GigabitEthernet0/0/0/1
     period: 200
 replaced:
@@ -50,7 +50,7 @@ replaced:
       system:
         mac: 00c2.4c00.bd15
     - name: GigabitEthernet0/0/0/0
-      period: 100
+      period: 300
     - name: GigabitEthernet0/0/0/1
       period: 300
 overridden:
@@ -62,7 +62,7 @@ overridden:
     - interface Bundle-Ether11
     - no lacp system mac 00c2.4c00.bd15
     - interface GigabitEthernet0/0/0/0
-    - no lacp period 100
+    - no lacp period 300
     - interface Bundle-Ether12
     - lacp churn logging both
     - lacp collector-max-delay 100
@@ -88,7 +88,7 @@ deleted:
     - interface Bundle-Ether11
     - no lacp system mac 00c2.4c00.bd15
     - interface GigabitEthernet0/0/0/0
-    - no lacp period 100
+    - no lacp period 300
     - interface GigabitEthernet0/0/0/1
     - no lacp period 200
   after:

--- a/tests/integration/targets/iosxr_logging_global/tests/common/_parsed.cfg
+++ b/tests/integration/targets/iosxr_logging_global/tests/common/_parsed.cfg
@@ -3,7 +3,6 @@ logging tls-server test
  trustpoint test2
  tls-hostname test2
 !
-logging file test path test maxfilesize 1024 severity info
 logging ipv4 dscp af11
 logging trap informational
 logging events display-location

--- a/tests/integration/targets/iosxr_logging_global/tests/common/_populate_config.yaml
+++ b/tests/integration/targets/iosxr_logging_global/tests/common/_populate_config.yaml
@@ -6,7 +6,6 @@
       - "  vrf test"
       - "  trustpoint test2"
       - "  tls-hostname test2"
-      - "logging file test path test maxfilesize 1024 severity info"
       - "logging ipv4 dscp af11"
       - "logging trap informational"
       - "logging events display-location"

--- a/tests/integration/targets/iosxr_logging_global/tests/common/deleted.yaml
+++ b/tests/integration/targets/iosxr_logging_global/tests/common/deleted.yaml
@@ -19,7 +19,7 @@
 
     - ansible.builtin.assert:
         that:
-          - result.commands|length == 13
+          - result.commands|length == 12
           - result.changed == true
           - ansible_facts.network_resources.logging_global == result.after
           - result.after == deleted.after

--- a/tests/integration/targets/iosxr_logging_global/tests/common/merged.yaml
+++ b/tests/integration/targets/iosxr_logging_global/tests/common/merged.yaml
@@ -15,11 +15,6 @@
             buffer_size: 1024
           events:
             display_location: true
-          files:
-            - maxfilesize: 1024
-              name: test
-              path: test
-              severity: info
           hostnameprefix: test
           hosts:
             - host: 1.1.1.1

--- a/tests/integration/targets/iosxr_logging_global/tests/common/overridden.yaml
+++ b/tests/integration/targets/iosxr_logging_global/tests/common/overridden.yaml
@@ -14,11 +14,6 @@
             severity: errors
           correlator:
             buffer_size: 1024
-          files:
-            - maxfilesize: 1024
-              name: test
-              path: test1
-              severity: info
           hostnameprefix: test1
           hosts:
             - host: 1.1.1.3

--- a/tests/integration/targets/iosxr_logging_global/tests/common/rendered.yaml
+++ b/tests/integration/targets/iosxr_logging_global/tests/common/rendered.yaml
@@ -14,11 +14,6 @@
         buffer_size: 1024
       events:
         display_location: true
-      files:
-        - maxfilesize: 1024
-          name: test
-          path: test
-          severity: info
       hostnameprefix: test
       hosts:
         - host: 1.1.1.1

--- a/tests/integration/targets/iosxr_logging_global/tests/common/replaced.yaml
+++ b/tests/integration/targets/iosxr_logging_global/tests/common/replaced.yaml
@@ -14,11 +14,6 @@
             severity: errors
           correlator:
             buffer_size: 1024
-          files:
-            - maxfilesize: 1024
-              name: test
-              path: test1
-              severity: info
           hostnameprefix: test1
           hosts:
             - host: 1.1.1.3

--- a/tests/integration/targets/iosxr_logging_global/vars/main.yaml
+++ b/tests/integration/targets/iosxr_logging_global/vars/main.yaml
@@ -11,7 +11,6 @@ merged:
     - logging monitor errors
     - logging trap informational
     - logging 1.1.1.1 vrf default severity critical port default
-    - logging file test path test maxfilesize 1024 severity info
     - logging source-interface GigabitEthernet0/0/0/0 vrf test
     - logging tls-server test tls-hostname test2
     - logging tls-server test trustpoint test2
@@ -24,11 +23,6 @@ merged:
       buffer_size: 1024
     events:
       display_location: true
-    files:
-      - maxfilesize: 1024
-        name: test
-        path: test
-        severity: info
     hostnameprefix: test
     hosts:
       - host: 1.1.1.1
@@ -66,18 +60,17 @@ replaced:
     - logging ipv6 dscp af11
     - logging trap critical
     - logging 1.1.1.3 vrf default severity critical port default
-    - logging file test path test1 maxfilesize 1024 severity info
     - logging tls-server test trustpoint test
   after:
     buffered:
       severity: errors
     correlator:
       buffer_size: 1024
-    files:
-      - maxfilesize: 1024
-        name: test
-        path: test1
-        severity: info
+    # files:
+    #   - maxfilesize: 1024
+    #     name: test
+    #     path: test1
+    #     severity: info # CML issue with file creation
     hostnameprefix: test1
     hosts:
       - host: 1.1.1.3

--- a/tests/integration/targets/iosxr_route_maps/vars/main.yaml
+++ b/tests/integration/targets/iosxr_route_maps/vars/main.yaml
@@ -1,6 +1,25 @@
 ---
 merged:
   commands:
+    - "route-policy SIMPLE_GLOBAL_ROUTE_POLICY"
+    - "apply A_NEW_ROUTE_POLICY"
+    - "set local-preference + 100\nset local-preference - 200\nset local-preference * 300\n"
+    - "set community (11011:1001) additive"
+    - "set weight 20000"
+    - "end-policy"
+    - "route-policy SIMPLE_CONDITION_ROUTE_POLICY"
+    - "if destination in SIMPLE_CONDITION_ROUTE_POLICY then"
+    - "pass"
+    - "else"
+    - "drop"
+    - "endif"
+    - "end-policy"
+    - "route-policy COMPLEX_CONDITION_ROUTE_POLICY"
+    - "if community matches-any (9119:1001) or community matches-any (11100:1001) then"
+    - "drop"
+    - "pass"
+    - "endif"
+    - "end-policy"
     - "route-policy COMPLEX_ROUTE_POLICY"
     - "if destination in A_RANDOM_POLICY_DUMMY then"
     - "drop"
@@ -10,25 +29,6 @@ merged:
     - "else"
     - "drop"
     - "endif"
-    - "endif"
-    - "end-policy"
-    - "route-policy SIMPLE_GLOBAL_ROUTE_POLICY"
-    - "apply A_NEW_ROUTE_POLICY"
-    - "set local-preference +100\nset local-preference -200\nset local-preference *300\n"
-    - "set community (11011:1001) additive"
-    - "set weight 20000"
-    - "end-policy"
-    - "route-policy COMPLEX_CONDITION_ROUTE_POLICY"
-    - "if community matches-any (9119:1001) or community matches-any (11100:1001) then"
-    - "drop"
-    - "pass"
-    - "endif"
-    - "end-policy"
-    - "route-policy SIMPLE_CONDITION_ROUTE_POLICY"
-    - "if destination in SIMPLE_CONDITION_ROUTE_POLICY then"
-    - "pass"
-    - "else"
-    - "drop"
     - "endif"
     - "end-policy"
   after:
@@ -79,7 +79,7 @@ overridden:
     - apply A_NEW_ROUTE_POLICY
     - set community test_comm_name
     - set weight 20000
-    - "set local-preference +100\nset local-preference -200\nset local-preference *300\n"
+    - "set local-preference + 100\nset local-preference - 200\nset local-preference * 300\n"
     - end-policy
     - route-policy COMPLEX_ROUTE_POLICY_overridden
     - if as-path in (ios-regex '_3117_', ios-regex '_600_') then

--- a/tests/integration/targets/iosxr_static_routes/tests/cli/merged.yaml
+++ b/tests/integration/targets/iosxr_static_routes/tests/cli/merged.yaml
@@ -31,7 +31,7 @@
 
                   - dest: 192.0.2.48/28
                     next_hops:
-                      - forward_outer_address: 192.0.2.10
+                      - forward_router_address: 192.0.2.10
                         interface: TenGigE0/0/0/23.2500
 
                   - dest: 192.168.17.0/24

--- a/tests/integration/targets/iosxr_static_routes/vars/main.yaml
+++ b/tests/integration/targets/iosxr_static_routes/vars/main.yaml
@@ -6,15 +6,15 @@ merged:
           routes:
             - dest: 0.0.0.0/0
               next_hops:
-                - forward_router_address: 10.0.151.254
+                - forward_router_address: 192.168.255.1
           safi: unicast
   commands:
     - router static
     - address-family ipv4 multicast
-    - 192.0.2.16/28 192.0.2.10 FastEthernet0/0/0/1 description LAB metric 120 tag
-      10
+    - 192.0.2.16/28 192.0.2.10 FastEthernet0/0/0/1 description LAB metric 120 tag 10
     - 192.0.2.16/28 FastEthernet0/0/0/5 track ip_sla_1
     - 192.0.2.32/28 192.0.2.11 100
+    - 192.0.2.48/28 192.0.2.10 TenGigE0/0/0/23.2500
     - 192.168.17.0/24 Loopback0
     - address-family ipv6 unicast
     - 2001:db8:1000::/36 FastEthernet0/0/0/7 description DC
@@ -40,7 +40,7 @@ merged:
           routes:
             - dest: 0.0.0.0/0
               next_hops:
-                - forward_router_address: 10.0.151.254
+                - forward_router_address: 192.168.255.1
           safi: unicast
         - afi: ipv4
           routes:
@@ -57,19 +57,23 @@ merged:
               next_hops:
                 - admin_distance: 100
                   forward_router_address: 192.0.2.11
+            - dest: 192.0.2.48/28
+              next_hops:
+                - forward_router_address: 192.0.2.10
+                  interface: TenGigE0/0/0/23.2500
             - dest: 192.168.17.0/24
               next_hops:
                 - interface: Loopback0
           safi: multicast
         - afi: ipv6
           routes:
-            - dest: 2001:db8:1000::/36
+            - dest: "2001:db8:1000::/36"
               next_hops:
                 - description: DC
                   interface: FastEthernet0/0/0/7
-                - forward_router_address: 2001:db8:2000:2::1
+                - forward_router_address: "2001:db8:2000:2::1"
                   interface: FastEthernet0/0/0/8
-            - dest: 2001:db8::/64
+            - dest: "2001:db8::/64"
               next_hops:
                 - interface: Loopback0
           safi: unicast
@@ -105,7 +109,7 @@ merged:
           routes:
             - dest: 0.0.0.0/0
               next_hops:
-                - forward_router_address: 10.0.151.254
+                - forward_router_address: 192.168.255.1
           safi: unicast
         - afi: ipv4
           routes:
@@ -122,19 +126,23 @@ merged:
               next_hops:
                 - admin_distance: 100
                   forward_router_address: 192.0.2.11
+            - dest: 192.0.2.48/28
+              next_hops:
+                - forward_router_address: 192.0.2.10
+                  interface: TenGigE0/0/0/23.2500
             - dest: 192.168.17.0/24
               next_hops:
                 - interface: Loopback0
           safi: multicast
         - afi: ipv6
           routes:
-            - dest: 2001:db8:1000::/36
+            - dest: "2001:db8:1000::/36"
               next_hops:
                 - description: DC
                   interface: FastEthernet0/0/0/7
-                - forward_router_address: 2001:db8:2000:2::1
+                - forward_router_address: "2001:db8:2000:2::1"
                   interface: FastEthernet0/0/0/8
-            - dest: 2001:db8::/64
+            - dest: "2001:db8::/64"
               next_hops:
                 - interface: Loopback0
           safi: unicast
@@ -149,12 +157,12 @@ merged:
                   vrflabel: 2301
             - dest: 192.0.2.80/28
               next_hops:
-                - dest_vrf: test_1
+                - description: rt_test_1
+                  dest_vrf: test_1
                   forward_router_address: 192.0.2.14
                   interface: FastEthernet0/0/0/2
                   track: ip_sla_2
                   vrflabel: 124
-                  description: rt_test_1
           safi: unicast
       vrf: DEV_SITE
     - address_families:
@@ -166,6 +174,7 @@ merged:
                   interface: Loopback1
           safi: unicast
       vrf: TEST_VRF
+
 replaced:
   before:
     - address_families:
@@ -173,7 +182,7 @@ replaced:
           routes:
             - dest: 0.0.0.0/0
               next_hops:
-                - forward_router_address: 10.0.151.254
+                - forward_router_address: 192.168.255.1
           safi: unicast
         - afi: ipv4
           routes:
@@ -233,7 +242,7 @@ replaced:
           routes:
             - dest: 0.0.0.0/0
               next_hops:
-                - forward_router_address: 10.0.151.254
+                - forward_router_address: 192.168.255.1
           safi: unicast
         - afi: ipv4
           routes:
@@ -294,7 +303,7 @@ overridden:
           routes:
             - dest: 0.0.0.0/0
               next_hops:
-                - forward_router_address: 10.0.151.254
+                - forward_router_address: 192.168.255.1
           safi: unicast
         - afi: ipv4
           routes:
@@ -351,7 +360,7 @@ round_trip:
           routes:
             - dest: 0.0.0.0/0
               next_hops:
-                - forward_router_address: 10.0.151.254
+                - forward_router_address: 192.168.255.1
           safi: unicast
         - afi: ipv4
           routes:

--- a/tests/integration/targets/iosxr_system/tasks/cli.yaml
+++ b/tests/integration/targets/iosxr_system/tasks/cli.yaml
@@ -10,6 +10,13 @@
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
+- name: Filter out specific tests from test_items
+  ansible.builtin.set_fact:
+    test_items: "{{ test_items | select('match', '^(?!.*(' + exclude_files | join('|') + ')$).*') | list }}"
+  vars:
+    exclude_files:
+      - set_name_servers.yaml
+
 - name: Run test case (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   vars:

--- a/tests/integration/targets/iosxr_system/tasks/netconf.yaml
+++ b/tests/integration/targets/iosxr_system/tasks/netconf.yaml
@@ -10,6 +10,15 @@
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
+# Exclude specific test cases from the list
+- name: Filter out specific tests from test_items
+  ansible.builtin.set_fact:
+    test_items: "{{ test_items | select('match', '^(?!.*(' + exclude_files | join('|') + ')$).*') | list }}"
+  vars:
+    exclude_files:
+      # Name server command is not supported in CML
+      - set_name_servers.yaml
+
 - name: Run test case (connection=ansible.netcommon.netconf)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"

--- a/tests/integration/targets/iosxr_vrf_interfaces/vars/main.yaml
+++ b/tests/integration/targets/iosxr_vrf_interfaces/vars/main.yaml
@@ -39,6 +39,7 @@ overridden:
     - name: GigabitEthernet0/0/0/0
     - name: GigabitEthernet0/0/0/1
       vrf_name: vrf_C
+    - name: GigabitEthernet0/0/0/2
   before:
     - name: Loopback888
     - name: Loopback999


### PR DESCRIPTION
##### SUMMARY
Fix downstream upstream related tests with CML

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test fixes

##### ADDITIONAL INFORMATION
This fixes tests related to downstream and upstream caused due to change to CML, certain commands are not available in the iosxr node in the cml causing the issues. Have made changes to fix the above
