### PR TITLE
fix deleted state for bgp_global

### DIFF
--- a/changelogs/fragments/fix_neighbor_deletion.yaml
+++ b/changelogs/fragments/fix_neighbor_deletion.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fixed deletion of all neighbors unintentionally getting deleted instead of only the specified ones in iosxr_bgp_global module.

--- a/tests/integration/targets/iosxr_bgp_global/tests/common/deleted_neighbor.yaml
+++ b/tests/integration/targets/iosxr_bgp_global/tests/common/deleted_neighbor.yaml
@@ -1,0 +1,58 @@
+---
+- ansible.builtin.debug:
+    msg: Start nxos_bgp_global deleted integration tests connection={{ ansible_connection}}
+
+- ansible.builtin.include_tasks: _remove_config.yaml
+
+- ansible.builtin.include_tasks: _populate_config.yaml
+
+- block:
+  - name: Push multiple neighbors
+    become: true
+    cisco.iosxr.iosxr_bgp_global:
+      config:
+        as_number: 65137
+        neighbors:
+          - neighbor_address: 192.168.253.1
+          - neighbor_address: 192.168.253.2
+          - neighbor_address: 192.168.253.3
+          - neighbor_address: 192.168.253.4
+      state: merged
+
+  - name: Delete one neighbor only
+    become: true
+    register: result
+    cisco.iosxr.iosxr_bgp_global:
+      config:
+        as_number: 65137
+        neighbors:
+          - neighbor_address: 192.168.253.4
+      state: deleted
+
+  - name: Validate single neighbor was removed
+    ansible.builtin.assert:
+      that:
+        - "'no neighbor 192.168.253.4' in result.commands"
+        - "'no neighbor 192.168.253.1' not in result.commands"
+        - "'no neighbor 192.168.253.2' not in result.commands"
+        - "'no neighbor 192.168.253.3' not in result.commands"
+        - result.changed == true
+
+  - name: Confirm idempotency
+    become: true
+    register: result
+    cisco.iosxr.iosxr_bgp_global:
+      config:
+        as_number: 65137
+        neighbors:
+          - neighbor_address: 192.168.253.4
+      state: deleted
+
+  - name: Validate no further change
+    ansible.builtin.assert:
+      that:
+        - result.commands|length == 0
+        - result.changed == false
+
+  always:
+    - ansible.builtin.include_tasks: _remove_config.yaml

--- a/tests/unit/modules/network/iosxr/test_iosxr_bgp_global.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_bgp_global.py
@@ -331,6 +331,35 @@ class TestIosxrBgpGlobalModule(TestIosxrModule):
 
         self.execute_module(changed=False, commands=[])
 
+    def test_iosxr_bgp_global_delete_single_neighbor(self):
+        run_cfg = dedent(
+            """\
+            router bgp 65137
+              neighbor 192.168.253.1
+              neighbor 192.168.253.2
+              neighbor 192.168.253.3
+              neighbor 192.168.253.4
+            """,
+        )
+        self.get_config.return_value = run_cfg
+        set_module_args(
+            dict(
+                config=dict(
+                    as_number="65137",
+                    neighbors=[
+                        dict(neighbor_address="192.168.253.4"),
+                    ],
+                ),
+                state="deleted",
+            ),
+        )
+        commands = [
+            "router bgp 65137",
+            "no neighbor 192.168.253.4",
+        ]
+        result = self.execute_module(changed=True)
+        self.assertEqual(sorted(result["commands"]), sorted(commands))
+
     def test_iosxr_bgp_global_deleted(self):
         run_cfg = dedent(
             """\
@@ -366,8 +395,6 @@ class TestIosxrBgpGlobalModule(TestIosxrModule):
             "no default-metric 4",
             "no socket receive-buffer-size 514",
             "no socket send-buffer-size 4098",
-            "no neighbor 192.0.2.11",
-            "no neighbor 192.0.2.14",
             "no vrf vrf1",
         ]
         result = self.execute_module(changed=True)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

fixes the issue customer is facing while deleting neighbors in bgp_global, when the customer provides just one neighbor (e.g., 192.168.253.4), the module deletes all neighbors not present in want, even though the user intends to delete just that one.

The proposed changes in this PR, only delete explicitly defined neighbors in the want dictionary and do not infer deletion of other neighbors.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes [ANA-733](https://issues.redhat.com/browse/ANA-733)
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`iosxr_bgp_global`

##### ADDITIONAL INFORMATION
Problem user facing when using state deleted:
```
- name: Delete only one BGP neighbor
  cisco.iosxr.iosxr_bgp_global:
    config:
      as_number: 65137
      neighbors:
        - neighbor_address: 192.168.253.4
    state: deleted
```
user configuration on device:
```
router bgp 65137
  neighbor 192.168.253.1
  neighbor 192.168.253.2
  neighbor 192.168.253.3
  neighbor 192.168.253.4
```
Expected outcome:
```
router bgp 65137
no neighbor 192.168.253.4
```
Actual outcome: 
```
router bgp 65137
no neighbor 192.168.253.1
no neighbor 192.168.253.2
no neighbor 192.168.253.3
no neighbor 192.168.253.4
```
