### PR TITLE
add typing_extensions in test_requirements.txt

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ protobuf
 pytest-ansible
 pytest-xdist
 pytest-cov
+typing-extensions


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The upstream CI is failing due to a missing dependency required by pytest-ansible for testing Ansible collections. This PR fixes that error and is consistent across all our collections.
`ModuleNotFoundError: No module named 'typing_extensions'`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- CI fix Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
https://github.com/ansible-collections/cisco.iosxr/actions/runs/15915118279/job/44904539512
```
