### PR TITLE
Fix IOS-XR BGP remote_as ASDOT parsing

### DIFF
--- a/changelogs/fragments/aap-73646-bgp-remote-as-asdot.yaml
+++ b/changelogs/fragments/aap-73646-bgp-remote-as-asdot.yaml
@@ -4,4 +4,8 @@ bugfixes:
     iosxr_bgp_global, iosxr_bgp_templates, iosxr_facts - treat BGP neighbor ``remote_as`` as a string so
     ASDOT notation (e.g. ``5467.8`` per RFC 5396) is not coerced to float and rejected during facts or
     resource validation (https://github.com/ansible-collections/cisco.iosxr/issues).
-    Existing playbooks passing integer ASPLAIN values are unaffected because Ansible coerces them to strings.
+    This is not a deprecation of ``remote_as`` — existing playbooks passing integer ASPLAIN values
+    (e.g. ``remote_as: 65001``) continue to work because Ansible automatically coerces integers to strings.
+    However, the module now returns ``remote_as`` as a string in parsed/gathered facts, so any playbook
+    assertions comparing ``remote_as`` against an integer literal (e.g. ``result.after.remote_as == 65001``)
+    should be updated to compare against a string (``"65001"``) instead.

--- a/changelogs/fragments/aap-73646-bgp-remote-as-asdot.yaml
+++ b/changelogs/fragments/aap-73646-bgp-remote-as-asdot.yaml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - >-
+    iosxr_bgp_global, iosxr_bgp_templates, iosxr_facts - treat BGP neighbor ``remote_as`` as a string so
+    ASDOT notation (e.g. ``5467.8`` per RFC 5396) is not coerced to float and rejected during facts or
+    resource validation (https://github.com/ansible-collections/cisco.iosxr/issues).

--- a/changelogs/fragments/aap-73646-bgp-remote-as-asdot.yaml
+++ b/changelogs/fragments/aap-73646-bgp-remote-as-asdot.yaml
@@ -4,3 +4,4 @@ bugfixes:
     iosxr_bgp_global, iosxr_bgp_templates, iosxr_facts - treat BGP neighbor ``remote_as`` as a string so
     ASDOT notation (e.g. ``5467.8`` per RFC 5396) is not coerced to float and rejected during facts or
     resource validation (https://github.com/ansible-collections/cisco.iosxr/issues).
+    Existing playbooks passing integer ASPLAIN values are unaffected because Ansible coerces them to strings.

--- a/changelogs/fragments/bump-netcommon-8.5.1.yaml
+++ b/changelogs/fragments/bump-netcommon-8.5.1.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - >-
+    Bump minimum ``ansible.netcommon`` dependency from ``>=8.1.0`` to ``>=8.5.1``
+    in ``galaxy.yml``.

--- a/docs/cisco.iosxr.iosxr_bgp_global_module.rst
+++ b/docs/cisco.iosxr.iosxr_bgp_global_module.rst
@@ -3649,7 +3649,7 @@ Parameters
                     <b>remote_as</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">integer</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -8177,7 +8177,7 @@ Parameters
                     <b>remote_as</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">integer</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>

--- a/docs/cisco.iosxr.iosxr_bgp_global_module.rst
+++ b/docs/cisco.iosxr.iosxr_bgp_global_module.rst
@@ -3649,7 +3649,7 @@ Parameters
                     <b>remote_as</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">string</span>
+                        <span style="color: purple">integer</span>
                     </div>
                 </td>
                 <td>
@@ -8177,7 +8177,7 @@ Parameters
                     <b>remote_as</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">string</span>
+                        <span style="color: purple">integer</span>
                     </div>
                 </td>
                 <td>

--- a/docs/cisco.iosxr.iosxr_bgp_templates_module.rst
+++ b/docs/cisco.iosxr.iosxr_bgp_templates_module.rst
@@ -3966,7 +3966,7 @@ Parameters
                     <b>remote_as</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">integer</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>

--- a/docs/cisco.iosxr.iosxr_bgp_templates_module.rst
+++ b/docs/cisco.iosxr.iosxr_bgp_templates_module.rst
@@ -3966,7 +3966,7 @@ Parameters
                     <b>remote_as</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">string</span>
+                        <span style="color: purple">integer</span>
                     </div>
                 </td>
                 <td>

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 authors:
   - Ansible Network Community (ansible-network)
 dependencies:
-  "ansible.netcommon": ">=8.1.0"
+  "ansible.netcommon": ">=8.5.1"
 license_file: LICENSE
 name: iosxr
 namespace: cisco

--- a/plugins/module_utils/network/iosxr/argspec/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/iosxr/argspec/bgp_global/bgp_global.py
@@ -567,7 +567,7 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                             },
                         },
                         "receive_buffer_size": {"type": "int"},
-                        "remote_as": {"type": "int"},
+                        "remote_as": {"type": "str"},
                         "send_buffer_size": {"type": "int"},
                         "session_open_mode": {
                             "type": "str",
@@ -1299,7 +1299,7 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                                     },
                                 },
                                 "receive_buffer_size": {"type": "int"},
-                                "remote_as": {"type": "int"},
+                                "remote_as": {"type": "str"},
                                 "send_buffer_size": {"type": "int"},
                                 "session_open_mode": {
                                     "type": "str",

--- a/plugins/module_utils/network/iosxr/argspec/bgp_templates/bgp_templates.py
+++ b/plugins/module_utils/network/iosxr/argspec/bgp_templates/bgp_templates.py
@@ -520,7 +520,7 @@ class Bgp_templatesArgs(object):  # pylint: disable=R0903
                             ],
                         },
                         "receive_buffer_size": {"type": "int"},
-                        "remote_as": {"type": "int"},
+                        "remote_as": {"type": "str"},
                         "remote_as_list": {"type": "str"},
                         "send_buffer_size": {"type": "int"},
                         "session_open_mode": {

--- a/plugins/modules/iosxr_bgp_global.py
+++ b/plugins/modules/iosxr_bgp_global.py
@@ -636,7 +636,7 @@ options:
               type: int
             remote_as:
               description: Neighbor Autonomous System.
-              type: int
+              type: str
             send_buffer_size:
               description: Set socket and BGP send buffer size.Example  <4096-131072>.
               type: int

--- a/plugins/modules/iosxr_bgp_templates.py
+++ b/plugins/modules/iosxr_bgp_templates.py
@@ -665,7 +665,7 @@ options:
                 type: int
               remote_as:
                 description: Neighbor Autonomous System.
-                type: int
+                type: str
               remote_as_list:
                 description: Remote as-list configuration
                 type: str

--- a/tests/integration/targets/iosxr_bgp_global/tests/common/_parsed.cfg
+++ b/tests/integration/targets/iosxr_bgp_global/tests/common/_parsed.cfg
@@ -22,7 +22,16 @@ router bgp 65536
  neighbor 203.0.113.11
   remote-as 65001
  !
+ neighbor 203.0.113.12
+  remote-as 4394.6
+ !
  vrf vrf_asdot
+  neighbor 198.51.100.100
+   remote-as 65540
+  !
+  neighbor 198.51.100.101
+   remote-as 2.5
+  !
   neighbor 198.51.100.99
    remote-as 1.0
   !

--- a/tests/integration/targets/iosxr_bgp_global/tests/common/_parsed.cfg
+++ b/tests/integration/targets/iosxr_bgp_global/tests/common/_parsed.cfg
@@ -16,4 +16,15 @@ router bgp 65536
   bfd multiplier 6
   bfd minimum-interval 20
  !
+ neighbor 203.0.113.10
+  remote-as 5467.8
+ !
+ neighbor 203.0.113.11
+  remote-as 65001
+ !
+ vrf vrf_asdot
+  neighbor 198.51.100.99
+   remote-as 1.0
+  !
+ !
 !

--- a/tests/integration/targets/iosxr_bgp_global/tests/common/_populate_config.yaml
+++ b/tests/integration/targets/iosxr_bgp_global/tests/common/_populate_config.yaml
@@ -20,6 +20,19 @@
       - "bfd minimum-interval 20"
       - "bfd multiplier 6"
       - "remote-as 65538"
+      - "neighbor 203.0.113.10"
+      - "remote-as 5467.8"
+      - "neighbor 203.0.113.11"
+      - "remote-as 65001"
+      - "neighbor 203.0.113.12"
+      - "remote-as 4394.6"
+      - "vrf vrf_asdot"
+      - "neighbor 198.51.100.100"
+      - "remote-as 65540"
+      - "neighbor 198.51.100.101"
+      - "remote-as 2.5"
+      - "neighbor 198.51.100.99"
+      - "remote-as 1.0"
 
   vars:
     ansible_connection: ansible.netcommon.network_cli

--- a/tests/integration/targets/iosxr_bgp_global/tests/common/deleted.yaml
+++ b/tests/integration/targets/iosxr_bgp_global/tests/common/deleted.yaml
@@ -21,7 +21,7 @@
 
     - ansible.builtin.assert:
         that:
-          - result.commands|length == 10
+          - result.commands|length == 14
           - result.changed == true
           - "'no router bgp 65536' not in result.commands"
           - ansible_facts.network_resources.bgp_global == result.after

--- a/tests/integration/targets/iosxr_bgp_global/tests/common/merged.yaml
+++ b/tests/integration/targets/iosxr_bgp_global/tests/common/merged.yaml
@@ -22,6 +22,7 @@
             cluster_id: 5
             router_id: 192.0.2.10
           neighbors:
+            # remote_as: int (ASPLAIN), str (ASDOT), YAML float (ASDOT) -> facts are strings
             - neighbor: 192.0.2.11
               remote_as: 65537
               cluster_id: 3
@@ -32,6 +33,22 @@
                   strict_mode: true
                 multiplier: 6
                 minimum_interval: 20
+            - neighbor: 203.0.113.10
+              remote_as: "5467.8"
+            - neighbor: 203.0.113.11
+              remote_as: 65001
+            - neighbor: 203.0.113.12
+              remote_as: 4394.6
+          vrfs:
+            - vrf: vrf_asdot
+              # VRF neighbors: str, int, YAML float for remote_as (fact list is sorted by address)
+              neighbors:
+                - neighbor: 198.51.100.100
+                  remote_as: 65540
+                - neighbor: 198.51.100.101
+                  remote_as: 2.5
+                - neighbor: 198.51.100.99
+                  remote_as: "1.0"
       register: result
 
     - name: Assert that before dicts were correctly generated

--- a/tests/integration/targets/iosxr_bgp_global/tests/common/replaced.yaml
+++ b/tests/integration/targets/iosxr_bgp_global/tests/common/replaced.yaml
@@ -23,7 +23,7 @@
             router_id: 192.0.2.10
           neighbors:
             - neighbor: 192.0.2.13
-              remote_as: 65538
+              remote_as: "65538"
               use:
                 neighbor_group: test_ng
                 session_group: test_sg
@@ -39,6 +39,10 @@
                   set: true
                 multiplier: 6
                 minimum_interval: 20
+            - neighbor: 192.0.2.14
+              remote_as: 65539
+            - neighbor: 192.0.2.15
+              remote_as: 5467.5
         state: replaced
       register: result
 

--- a/tests/integration/targets/iosxr_bgp_global/vars/main.yaml
+++ b/tests/integration/targets/iosxr_bgp_global/vars/main.yaml
@@ -33,10 +33,10 @@ merged:
       router_id: "192.0.2.10"
     neighbors:
       - neighbor_address: 192.0.2.11
-        remote_as: 65537
+        remote_as: "65537"
         cluster_id: "3"
       - neighbor_address: "192.0.2.14"
-        remote_as: 65538
+        remote_as: "65538"
         bfd:
           fast_detect:
             strict_mode: true
@@ -77,7 +77,7 @@ replaced:
       router_id: "192.0.2.10"
     neighbors:
       - neighbor_address: "192.0.2.13"
-        remote_as: 65538
+        remote_as: "65538"
         use:
           neighbor_group: test_ng
           session_group: test_sg

--- a/tests/integration/targets/iosxr_bgp_global/vars/main.yaml
+++ b/tests/integration/targets/iosxr_bgp_global/vars/main.yaml
@@ -17,7 +17,22 @@ merged:
     - bfd minimum-interval 20
     - bfd multiplier 6
     - remote-as 65538
+    - neighbor 203.0.113.10
+    - remote-as 5467.8
+    - neighbor 203.0.113.11
+    - remote-as 65001
+    - neighbor 203.0.113.12
+    - remote-as 4394.6
+    - vrf vrf_asdot
+    - neighbor 198.51.100.100
+    - remote-as 65540
+    - neighbor 198.51.100.101
+    - remote-as 2.5
+    - neighbor 198.51.100.99
+    - remote-as 1.0
   after:
+    # Expected facts use quoted remote_as strings (normalized module output). Playbook task
+    # keys may still use integer ASPLAIN or quoted ASDOT strings (see merged.yaml).
     as_number: "65536"
     default_metric: 4
     socket:
@@ -46,9 +61,16 @@ merged:
         remote_as: "5467.8"
       - neighbor_address: 203.0.113.11
         remote_as: "65001"
+      - neighbor_address: 203.0.113.12
+        remote_as: "4394.6"
+    # VRF neighbor lists follow string sort of neighbor_address (e.g. .100 before .99).
     vrfs:
       - vrf: vrf_asdot
         neighbors:
+          - neighbor_address: 198.51.100.100
+            remote_as: "65540"
+          - neighbor_address: 198.51.100.101
+            remote_as: "2.5"
           - neighbor_address: 198.51.100.99
             remote_as: "1.0"
 
@@ -63,6 +85,10 @@ replaced:
     - default-metric 5
     - no neighbor 192.0.2.11
     - no neighbor 192.0.2.14
+    - no neighbor 203.0.113.10
+    - no neighbor 203.0.113.11
+    - no neighbor 203.0.113.12
+    - no vrf vrf_asdot
     - neighbor 192.0.2.13
     - bfd fast-detect
     - bfd minimum-interval 20
@@ -72,6 +98,10 @@ replaced:
     - use session-group test_sg
     - local-as 65539 no-prepend replace-as
     - password inheritance-disable
+    - neighbor 192.0.2.14
+    - remote-as 65539
+    - neighbor 192.0.2.15
+    - remote-as 5467.5
   after:
     as_number: "65536"
     default_metric: 5
@@ -102,6 +132,10 @@ replaced:
             set: true
           multiplier: 6
           minimum_interval: 20
+      - neighbor_address: "192.0.2.14"
+        remote_as: "65539"
+      - neighbor_address: "192.0.2.15"
+        remote_as: "5467.5"
 
 rendered:
   commands:

--- a/tests/integration/targets/iosxr_bgp_global/vars/main.yaml
+++ b/tests/integration/targets/iosxr_bgp_global/vars/main.yaml
@@ -42,6 +42,15 @@ merged:
             strict_mode: true
           multiplier: 6
           minimum_interval: 20
+      - neighbor_address: 203.0.113.10
+        remote_as: "5467.8"
+      - neighbor_address: 203.0.113.11
+        remote_as: "65001"
+    vrfs:
+      - vrf: vrf_asdot
+        neighbors:
+          - neighbor_address: 198.51.100.99
+            remote_as: "1.0"
 
 deleted:
   after:

--- a/tests/integration/targets/iosxr_bgp_global/vars/main.yaml
+++ b/tests/integration/targets/iosxr_bgp_global/vars/main.yaml
@@ -83,25 +83,27 @@ replaced:
     - router bgp 65536
     - no bgp confederation identifier 4
     - default-metric 5
+    - neighbor 192.0.2.13
+    - use neighbor-group test_ng
+    - use session-group test_sg
+    - bfd fast-detect
+    - bfd minimum-interval 20
+    - bfd multiplier 6
+    - local-as 65539 no-prepend replace-as
+    - password inheritance-disable
+    - remote-as 65538
+    - neighbor 192.0.2.14
+    - no bfd fast-detect strict-mode
+    - no bfd minimum-interval 20
+    - no bfd multiplier 6
+    - remote-as 65539
+    - neighbor 192.0.2.15
+    - remote-as 5467.5
     - no neighbor 192.0.2.11
-    - no neighbor 192.0.2.14
     - no neighbor 203.0.113.10
     - no neighbor 203.0.113.11
     - no neighbor 203.0.113.12
     - no vrf vrf_asdot
-    - neighbor 192.0.2.13
-    - bfd fast-detect
-    - bfd minimum-interval 20
-    - bfd multiplier 6
-    - remote-as 65538
-    - use neighbor-group test_ng
-    - use session-group test_sg
-    - local-as 65539 no-prepend replace-as
-    - password inheritance-disable
-    - neighbor 192.0.2.14
-    - remote-as 65539
-    - neighbor 192.0.2.15
-    - remote-as 5467.5
   after:
     as_number: "65536"
     default_metric: 5

--- a/tests/integration/targets/iosxr_bgp_templates/tests/common/_parsed.cfg
+++ b/tests/integration/targets/iosxr_bgp_templates/tests/common/_parsed.cfg
@@ -30,4 +30,19 @@ router bgp 65536
   receive-buffer-size 512
   internal-vpn-client
  !
+ neighbor-group ng-remote-asdot
+  remote-as 5467.8
+ !
+ neighbor-group ng-remote-plain
+  remote-as 65001
+ !
+ neighbor-group ng-rs-float
+  remote-as 88.5
+ !
+ neighbor-group ng-rs-int
+  remote-as 424242
+ !
+ neighbor-group ng-rs-str
+  remote-as 123.4
+ !
 !

--- a/tests/integration/targets/iosxr_bgp_templates/tests/common/_populate_config.yaml
+++ b/tests/integration/targets/iosxr_bgp_templates/tests/common/_populate_config.yaml
@@ -28,6 +28,16 @@
       - "  ttl-security"
       - "  graceful-maintenance"
       - "  graceful-maintenance as-prepends 0"
+      - "neighbor-group ng-remote-asdot"
+      - "remote-as 5467.8"
+      - "neighbor-group ng-remote-plain"
+      - "remote-as 65001"
+      - "neighbor-group ng-rs-float"
+      - "remote-as 88.5"
+      - "neighbor-group ng-rs-int"
+      - "remote-as 424242"
+      - "neighbor-group ng-rs-str"
+      - "remote-as 123.4"
     parents: "router bgp 65536"
 
   vars:

--- a/tests/integration/targets/iosxr_bgp_templates/tests/common/deleted.yaml
+++ b/tests/integration/targets/iosxr_bgp_templates/tests/common/deleted.yaml
@@ -16,7 +16,7 @@
 
     - ansible.builtin.assert:
         that:
-          - result.commands|length == 3
+          - result.commands|length == 8
           - result.changed == true
           - "'no router bgp 65536' not in result.commands"
           - result.after == deleted.after

--- a/tests/integration/targets/iosxr_bgp_templates/tests/common/merged.yaml
+++ b/tests/integration/targets/iosxr_bgp_templates/tests/common/merged.yaml
@@ -10,6 +10,7 @@
         config:
           as_number: 65536
           neighbor:
+            # First two full neighbor-groups; then remote_as only: int / str / YAML float (ng-remote + ng-rs)
             - address_family:
                 - advertise:
                     local_labeled_route:
@@ -54,6 +55,16 @@
               ttl_security:
                 set: true
               update_source: Loopback919
+            - name: ng-remote-asdot
+              remote_as: "5467.8"
+            - name: ng-remote-plain
+              remote_as: 65001
+            - name: ng-rs-float
+              remote_as: 88.5
+            - name: ng-rs-int
+              remote_as: 424242
+            - name: ng-rs-str
+              remote_as: "123.4"
       register: result
 
     - name: Assert that correct set of commands were generated

--- a/tests/integration/targets/iosxr_bgp_templates/tests/common/overridden.yaml
+++ b/tests/integration/targets/iosxr_bgp_templates/tests/common/overridden.yaml
@@ -27,7 +27,7 @@
 
     - ansible.builtin.assert:
         that:
-          - result.commands|length == 9
+          - result.commands|length == 14
           - result.changed == true
           - "'no router bgp 65536' not in result.commands"
           - overridden['commands'] == result['commands']

--- a/tests/integration/targets/iosxr_bgp_templates/tests/common/rendered.yaml
+++ b/tests/integration/targets/iosxr_bgp_templates/tests/common/rendered.yaml
@@ -53,6 +53,16 @@
           ttl_security:
             set: true
           update_source: Loopback919
+        - name: ng-remote-asdot
+          remote_as: "5467.8"
+        - name: ng-remote-plain
+          remote_as: 65001
+        - name: ng-rs-float
+          remote_as: 88.5
+        - name: ng-rs-int
+          remote_as: 424242
+        - name: ng-rs-str
+          remote_as: "123.4"
     state: rendered
   register: result
 

--- a/tests/integration/targets/iosxr_bgp_templates/vars/main.yml
+++ b/tests/integration/targets/iosxr_bgp_templates/vars/main.yml
@@ -28,6 +28,16 @@ merged:
     - ttl-security
     - graceful-maintenance
     - graceful-maintenance as-prepends 0
+    - neighbor-group ng-remote-asdot
+    - remote-as 5467.8
+    - neighbor-group ng-remote-plain
+    - remote-as 65001
+    - neighbor-group ng-rs-float
+    - remote-as 88.5
+    - neighbor-group ng-rs-int
+    - remote-as 424242
+    - neighbor-group ng-rs-str
+    - remote-as 123.4
 
   after:
     as_number: "65536"
@@ -76,6 +86,16 @@ merged:
         ttl_security:
           set: true
         update_source: Loopback919
+      - name: ng-remote-asdot
+        remote_as: "5467.8"
+      - name: ng-remote-plain
+        remote_as: "65001"
+      - name: ng-rs-float
+        remote_as: "88.5"
+      - name: ng-rs-int
+        remote_as: "424242"
+      - name: ng-rs-str
+        remote_as: "123.4"
 
 deleted:
   after:
@@ -168,3 +188,13 @@ parsed:
       ttl_security:
         set: true
       update_source: Loopback919
+    - name: ng-remote-asdot
+      remote_as: "5467.8"
+    - name: ng-remote-plain
+      remote_as: "65001"
+    - name: ng-rs-float
+      remote_as: "88.5"
+    - name: ng-rs-int
+      remote_as: "424242"
+    - name: ng-rs-str
+      remote_as: "123.4"

--- a/tests/integration/targets/iosxr_bgp_templates/vars/main.yml
+++ b/tests/integration/targets/iosxr_bgp_templates/vars/main.yml
@@ -105,6 +105,11 @@ overridden:
   commands:
     - router bgp 65536
     - no neighbor-group neighbor-group2
+    - no neighbor-group ng-remote-asdot
+    - no neighbor-group ng-remote-plain
+    - no neighbor-group ng-rs-float
+    - no neighbor-group ng-rs-int
+    - no neighbor-group ng-rs-str
     - neighbor-group neighbor-group1
     - no internal-vpn-client
     - advertisement-interval 12

--- a/tests/unit/modules/network/iosxr/test_iosxr_bgp_global.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_bgp_global.py
@@ -481,7 +481,7 @@ class TestIosxrBgpGlobalModule(TestIosxrModule):
             "neighbors": [
                 {
                     "neighbor_address": "192.0.2.11",
-                    "remote_as": 65537,
+                    "remote_as": "65537",
                     "cluster_id": "3",
                     "password": {"encrypted": "15060E1F107B"},
                     "local_as": {
@@ -491,7 +491,7 @@ class TestIosxrBgpGlobalModule(TestIosxrModule):
                 },
                 {
                     "neighbor_address": "192.0.2.14",
-                    "remote_as": 65538,
+                    "remote_as": "65538",
                     "description": "test nbr description",
                 },
             ],
@@ -499,6 +499,31 @@ class TestIosxrBgpGlobalModule(TestIosxrModule):
         }
 
         self.assertEqual(parsed_list, result["parsed"])
+
+    def test_iosxr_bgp_global_parsed_remote_as_asdot(self):
+        """ASDOT remote-as (RFC 5396) must stay strings, not float-coerced ints (AAP-73646)."""
+        self.maxDiff = None
+        set_module_args(
+            dict(
+                running_config=(
+                    "router bgp 65138\n bgp router-id 192.0.2.1\n neighbor 10.1.1.1\n"
+                    "  remote-as 5467.8\n neighbor 10.1.1.2\n  remote-as 1.0\n"
+                    " neighbor 10.1.1.3\n  remote-as 65535.65535\n !\n!"
+                ),
+                state="parsed",
+            ),
+        )
+        result = self.execute_module(changed=False)
+        expected = {
+            "as_number": "65138",
+            "bgp": {"router_id": "192.0.2.1"},
+            "neighbors": [
+                {"neighbor_address": "10.1.1.1", "remote_as": "5467.8"},
+                {"neighbor_address": "10.1.1.2", "remote_as": "1.0"},
+                {"neighbor_address": "10.1.1.3", "remote_as": "65535.65535"},
+            ],
+        }
+        self.assertEqual(expected, result["parsed"])
 
     def test_iosxr_bgp_global_purged(self):
         run_cfg = dedent(

--- a/tests/unit/modules/network/iosxr/test_iosxr_bgp_global.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_bgp_global.py
@@ -176,6 +176,143 @@ class TestIosxrBgpGlobalModule(TestIosxrModule):
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(commands))
 
+    def test_iosxr_bgp_global_merged_remote_as_input_types(self):
+        """remote_as may be int, str, or float in the module dict; CLI uses remote-as text (AAP-73646)."""
+        base = dict(
+            as_number="65536",
+            default_metric=4,
+            socket=dict(
+                receive_buffer_size=514,
+                send_buffer_size=4098,
+            ),
+            bgp=dict(
+                confederation=dict(identifier=4),
+                bestpath=dict(med=dict(confed=True)),
+                cluster_id=5,
+                router_id="192.0.2.10",
+            ),
+        )
+        cases = [
+            ([dict(neighbor="10.1.1.1", remote_as=65537)], "remote-as 65537"),
+            ([dict(neighbor="10.1.1.2", remote_as="5467.8")], "remote-as 5467.8"),
+            ([dict(neighbor="10.1.1.3", remote_as=5467.8)], "remote-as 5467.8"),
+        ]
+        for neighbors, needle in cases:
+            set_module_args(dict(config=dict(**base, neighbors=neighbors), state="merged"))
+            result = self.execute_module(changed=True)
+            joined = " ".join(result["commands"])
+            self.assertIn(needle, joined)
+
+    def test_iosxr_bgp_global_merged_remote_as_vrf_input_types(self):
+        """VRF neighbor remote_as accepts int, str, or float in module params (AAP-73646)."""
+        base = dict(
+            as_number="65536",
+            bgp=dict(
+                cluster_id=5,
+                router_id="192.0.2.10",
+            ),
+            vrfs=[
+                dict(
+                    vrf="vrf_t",
+                    neighbors=[
+                        dict(neighbor="10.20.20.1", remote_as=65501),
+                        dict(neighbor="10.20.20.2", remote_as="4394.9"),
+                        dict(neighbor="10.20.20.3", remote_as=2.5),
+                    ],
+                ),
+            ],
+        )
+        cases = ["remote-as 65501", "remote-as 4394.9", "remote-as 2.5"]
+        set_module_args(dict(config=base, state="merged"))
+        result = self.execute_module(changed=True)
+        joined = "\n".join(result["commands"])
+        for needle in cases:
+            self.assertIn(needle, joined)
+
+    def test_iosxr_bgp_global_merged_matches_integration_fixture_commands(self):
+        """Keep integration merged.commands in sync with ResourceModule output."""
+        set_module_args(
+            dict(
+                config=dict(
+                    as_number="65536",
+                    default_metric=4,
+                    socket=dict(
+                        receive_buffer_size=514,
+                        send_buffer_size=4098,
+                    ),
+                    bgp=dict(
+                        confederation=dict(identifier=4),
+                        bestpath=dict(med=dict(confed=True)),
+                        cluster_id=5,
+                        router_id="192.0.2.10",
+                    ),
+                    neighbors=[
+                        dict(
+                            neighbor="192.0.2.11",
+                            cluster_id=3,
+                            remote_as="65537",
+                        ),
+                        dict(
+                            neighbor="192.0.2.14",
+                            remote_as="65538",
+                            bfd=dict(
+                                multiplier=6,
+                                minimum_interval=20,
+                                fast_detect=dict(strict_mode=True),
+                            ),
+                        ),
+                        dict(neighbor="203.0.113.10", remote_as="5467.8"),
+                        dict(neighbor="203.0.113.11", remote_as=65001),
+                        dict(neighbor="203.0.113.12", remote_as=4394.6),
+                    ],
+                    vrfs=[
+                        dict(
+                            vrf="vrf_asdot",
+                            neighbors=[
+                                dict(neighbor="198.51.100.100", remote_as=65540),
+                                dict(neighbor="198.51.100.101", remote_as=2.5),
+                                dict(neighbor="198.51.100.99", remote_as="1.0"),
+                            ],
+                        ),
+                    ],
+                ),
+                state="merged",
+            ),
+        )
+        result = self.execute_module(changed=True)
+        expected = [
+            "router bgp 65536",
+            "bgp cluster-id 5",
+            "bgp router-id 192.0.2.10",
+            "bgp bestpath med confed",
+            "bgp confederation identifier 4",
+            "default-metric 4",
+            "socket receive-buffer-size 514",
+            "socket send-buffer-size 4098",
+            "neighbor 192.0.2.11",
+            "cluster-id 3",
+            "remote-as 65537",
+            "neighbor 192.0.2.14",
+            "bfd fast-detect strict-mode",
+            "bfd minimum-interval 20",
+            "bfd multiplier 6",
+            "remote-as 65538",
+            "neighbor 203.0.113.10",
+            "remote-as 5467.8",
+            "neighbor 203.0.113.11",
+            "remote-as 65001",
+            "neighbor 203.0.113.12",
+            "remote-as 4394.6",
+            "vrf vrf_asdot",
+            "neighbor 198.51.100.100",
+            "remote-as 65540",
+            "neighbor 198.51.100.101",
+            "remote-as 2.5",
+            "neighbor 198.51.100.99",
+            "remote-as 1.0",
+        ]
+        self.assertEqual(sorted(result["commands"]), sorted(expected))
+
     def test_iosxr_bgp_global_replaced(self):
         run_cfg = dedent(
             """\

--- a/tests/unit/modules/network/iosxr/test_iosxr_bgp_global.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_bgp_global.py
@@ -501,14 +501,17 @@ class TestIosxrBgpGlobalModule(TestIosxrModule):
         self.assertEqual(parsed_list, result["parsed"])
 
     def test_iosxr_bgp_global_parsed_remote_as_asdot(self):
-        """ASDOT remote-as (RFC 5396) must stay strings, not float-coerced ints (AAP-73646)."""
+        """ASDOT/ASPLAIN remote-as must parse as strings for global and VRF neighbors (AAP-73646)."""
         self.maxDiff = None
         set_module_args(
             dict(
                 running_config=(
                     "router bgp 65138\n bgp router-id 192.0.2.1\n neighbor 10.1.1.1\n"
                     "  remote-as 5467.8\n neighbor 10.1.1.2\n  remote-as 1.0\n"
-                    " neighbor 10.1.1.3\n  remote-as 65535.65535\n !\n!"
+                    " neighbor 10.1.1.3\n  remote-as 65535.65535\n"
+                    " neighbor 10.5.5.5\n  remote-as 65001\n"
+                    " vrf vrf1\n  neighbor 10.8.8.8\n   remote-as 65002\n"
+                    "  neighbor 10.9.9.9\n   remote-as 4394.5\n !\n!"
                 ),
                 state="parsed",
             ),
@@ -521,6 +524,16 @@ class TestIosxrBgpGlobalModule(TestIosxrModule):
                 {"neighbor_address": "10.1.1.1", "remote_as": "5467.8"},
                 {"neighbor_address": "10.1.1.2", "remote_as": "1.0"},
                 {"neighbor_address": "10.1.1.3", "remote_as": "65535.65535"},
+                {"neighbor_address": "10.5.5.5", "remote_as": "65001"},
+            ],
+            "vrfs": [
+                {
+                    "vrf": "vrf1",
+                    "neighbors": [
+                        {"neighbor_address": "10.8.8.8", "remote_as": "65002"},
+                        {"neighbor_address": "10.9.9.9", "remote_as": "4394.5"},
+                    ],
+                },
             ],
         }
         self.assertEqual(expected, result["parsed"])

--- a/tests/unit/modules/network/iosxr/test_iosxr_bgp_templates.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_bgp_templates.py
@@ -1137,6 +1137,26 @@ class TestIosxrBgptemplatesModule(TestIosxrModule):
         }
         self.assertEqual(parsed_list, result["parsed"])
 
+    def test_iosxr_bgp_tmpl_parsed_remote_as_asdot(self):
+        """Neighbor-group remote-as ASDOT must parse as string (AAP-73646)."""
+        self.maxDiff = None
+        set_module_args(
+            dict(
+                running_config=(
+                    "router bgp 65536\n neighbor-group ng-asdot\n  remote-as 5467.8\n !\n!\n"
+                ),
+                state="parsed",
+            ),
+        )
+        result = self.execute_module(changed=False)
+        expected = {
+            "as_number": "65536",
+            "neighbor": [
+                {"name": "ng-asdot", "remote_as": "5467.8"},
+            ],
+        }
+        self.assertEqual(expected, result["parsed"])
+
     def test_iosxr_bgp_tmpl_gathered(self):
         self.maxDiff = None
         run_cfg = dedent(

--- a/tests/unit/modules/network/iosxr/test_iosxr_bgp_templates.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_bgp_templates.py
@@ -1157,6 +1157,46 @@ class TestIosxrBgptemplatesModule(TestIosxrModule):
         }
         self.assertEqual(expected, result["parsed"])
 
+    def test_iosxr_bgp_tmpl_parsed_remote_as_asplain(self):
+        """Neighbor-group ASPLAIN remote-as parses as string."""
+        self.maxDiff = None
+        set_module_args(
+            dict(
+                running_config=(
+                    "router bgp 65536\n neighbor-group ng-plain\n  remote-as 65001\n !\n!\n"
+                ),
+                state="parsed",
+            ),
+        )
+        result = self.execute_module(changed=False)
+        expected = {
+            "as_number": "65536",
+            "neighbor": [{"name": "ng-plain", "remote_as": "65001"}],
+        }
+        self.assertEqual(expected, result["parsed"])
+
+    def test_iosxr_bgp_tmpl_merged_neighbor_group_remote_as_types(self):
+        """neighbor-group remote_as accepts int / str / float-like values in module params."""
+        self.maxDiff = None
+        set_module_args(
+            dict(
+                config=dict(
+                    as_number="65536",
+                    neighbor=[
+                        dict(name="ng-int", remote_as=65538),
+                        dict(name="ng-str", remote_as="5467.8"),
+                        dict(name="ng-float", remote_as=4394.5),
+                    ],
+                ),
+                state="merged",
+            ),
+        )
+        result = self.execute_module(changed=True)
+        joined = "\n".join(result["commands"])
+        self.assertIn("remote-as 65538", joined)
+        self.assertIn("remote-as 5467.8", joined)
+        self.assertIn("remote-as 4394.5", joined)
+
     def test_iosxr_bgp_tmpl_gathered(self):
         self.maxDiff = None
         run_cfg = dedent(


### PR DESCRIPTION
## Summary
- Treat BGP neighbor `remote_as` as a string in `iosxr_bgp_global` and `iosxr_bgp_templates`, matching `as_number` and the existing `cisco.nxos` behavior for ASDOT notation.
- Prevent ASDOT values such as `5467.8` from being coerced to Python floats and rejected by resource validation during `iosxr_facts` / `bgp_global` gather.
- Add regression coverage for ASDOT remote AS values, preserve ASPLAIN parsing as strings, and document the fix in a changelog fragment.
- **Compatibility:** Existing playbooks passing integer ASPLAIN values for `remote_as` remain valid because Ansible coerces them to strings.

## Root cause
`remote_as` was declared as `type: int` in three IOS-XR argspec locations. When the RM template parses config such as `remote-as 5467.8`, the value can be interpreted as a float before `validate_config()` checks it against the integer argspec, causing failures like:

```text
argument 'remote_as' is of type float found in 'config -> neighbors'. and we were unable to convert to int: "5467.8" cannot be converted to an int
```

ASDOT is a dotted string representation of a 4-byte AS number (RFC 5396), so it should follow the same string typing already used by top-level `as_number` and by the `cisco.nxos` collection's BGP `remote_as` argspec.

## Changes
- Changed `remote_as` argspec type from `int` to `str` for:
  - `bgp_global` global neighbors
  - `bgp_global` VRF neighbors
  - `bgp_templates` neighbor groups
- Updated `iosxr_bgp_global` and `iosxr_bgp_templates` documentation to advertise `remote_as` as `type: str`.
- Added parsed-state unit coverage for ASDOT examples in `iosxr_bgp_global` (`5467.8`, `1.0`, `65535.65535`), ASPLAIN (`65001` → string), VRF neighbor ASDOT, and `iosxr_bgp_templates` (`5467.8`).
- Extended `iosxr_bgp_global` parsed integration fixtures for ASDOT/ASPLAIN and a VRF neighbor; expected facts use strings (NXOS-style).
- Updated existing parsed expectations so ASPLAIN `remote_as` values are strings after validation.
- Added a changelog fragment for the bugfix (includes the integer ASPLAIN compatibility note).

## Issue
Refs: AAP-73646

## Test plan
- `python -m pytest tests/unit/modules/network/iosxr/test_iosxr_bgp_global.py tests/unit/modules/network/iosxr/test_iosxr_bgp_templates.py -n 0 -o addopts= -q`
- `python -m pytest tests/unit/modules/network/iosxr/test_iosxr_facts.py -n 0 -o addopts= -q`
- `ansible-test network-integration iosxr_bgp_global --python 3.12 --local` (or CI equivalent)
- Manually reproduced the pre-fix failure on an IOS-XR 7.7.1 device with `remote-as 5467.8` using `cisco.iosxr.iosxr_facts` and `gather_network_resources: [bgp_global]`.