### PR TITLE
Remediate deprecated ansible.module utils dependencies cisco.iosxr

### DIFF
--- a/changelogs/fragments/ACA-6582_Remediate_deprecated_ansible_module_utils_dependencies.yaml
+++ b/changelogs/fragments/ACA-6582_Remediate_deprecated_ansible_module_utils_dependencies.yaml
@@ -1,0 +1,17 @@
+minor_changes:
+  - Remediate deprecated ``warnings`` parameter in ``exit_json`` calls by using
+    ``AnsibleModule.warn()`` across all iosxr modules to address deprecation
+    warning from ansible-core 2.23.
+
+  - Fixed for iosxr_lldp_interfaces, iosxr_lldp_global, iosxr_lag_interfaces, iosxr_lacp_interfaces, iosxr_lacp, iosxr_l3_interfaces, iosxr_l2_interfaces, iosxr_interfaces, iosxr_acls, iosxr_static_routes, iosxr_ping,iosxr_banner, iosxr_config, iosxr_system, iosxr_command, iosxr_user, iosxr_netconf
+  
+  - For iosxr_vrf_interfaces, iosxr_vrf_global, iosxr_vrf_address_family, iosxr_snmp_server, iosxr_route_maps, iosxr_prefix_lists, iosxr_ospfv3, iosxr_ospfv2, iosxr_ospf_interfaces, iosxr_ntp_global, iosxr_logging_global, iosxr_hostname, iosxr_bgp_templates, iosxr_bgp_neighbor_address_family, iosxr_bgp_global, iosxr_bgp_address_family, iosxr_acl_interfaces
+    modules ,fix will be done via netcommon ResourceModule.result change (Upstream to iosxr)
+  
+  - No changes for fail_json since it uses msg format already , except for ping module where currently warning is not being set.
+  
+  - Remediate deprecated 'to_text' from 'ansible.module_utils._text' and replaced with ansible.module_utils.common.text.converters.
+  
+  - Remediate deprecated `ansible.module_utils.common._collections_compat` module and replaced with `collections.abc` from the Python standard library.
+  
+  - Remediate deprecated 'to_bytes' from 'ansible.module_utils._text' and replaced with ansible.module_utils.common.text.converters.

--- a/changelogs/fragments/ACA-6582_Remediate_deprecated_ansible_module_utils_dependencies.yaml
+++ b/changelogs/fragments/ACA-6582_Remediate_deprecated_ansible_module_utils_dependencies.yaml
@@ -4,14 +4,14 @@ minor_changes:
     warning from ansible-core 2.23.
 
   - Fixed for iosxr_lldp_interfaces, iosxr_lldp_global, iosxr_lag_interfaces, iosxr_lacp_interfaces, iosxr_lacp, iosxr_l3_interfaces, iosxr_l2_interfaces, iosxr_interfaces, iosxr_acls, iosxr_static_routes, iosxr_ping,iosxr_banner, iosxr_config, iosxr_system, iosxr_command, iosxr_user, iosxr_netconf
-  
+
   - For iosxr_vrf_interfaces, iosxr_vrf_global, iosxr_vrf_address_family, iosxr_snmp_server, iosxr_route_maps, iosxr_prefix_lists, iosxr_ospfv3, iosxr_ospfv2, iosxr_ospf_interfaces, iosxr_ntp_global, iosxr_logging_global, iosxr_hostname, iosxr_bgp_templates, iosxr_bgp_neighbor_address_family, iosxr_bgp_global, iosxr_bgp_address_family, iosxr_acl_interfaces
     modules ,fix will be done via netcommon ResourceModule.result change (Upstream to iosxr)
-  
+
   - No changes for fail_json since it uses msg format already , except for ping module where currently warning is not being set.
-  
+
   - Remediate deprecated 'to_text' from 'ansible.module_utils._text' and replaced with ansible.module_utils.common.text.converters.
-  
+
   - Remediate deprecated `ansible.module_utils.common._collections_compat` module and replaced with `collections.abc` from the Python standard library.
-  
+
   - Remediate deprecated 'to_bytes' from 'ansible.module_utils._text' and replaced with ansible.module_utils.common.text.converters.

--- a/iosxr
+++ b/iosxr
@@ -1,1 +1,0 @@
-/Users/abjha/ansible-dev/ansible-collections/cisco/iosxr

--- a/iosxr
+++ b/iosxr
@@ -1,0 +1,1 @@
+/Users/abjha/ansible-dev/ansible-collections/cisco/iosxr

--- a/plugins/cliconf/iosxr.py
+++ b/plugins/cliconf/iosxr.py
@@ -193,8 +193,8 @@ import json
 import re
 
 from ansible.errors import AnsibleConnectionFailure
-from ansible.module_utils._text import to_text
-from ansible.module_utils.common._collections_compat import Mapping
+from ansible.module_utils.common.text.converters import to_text
+from collections.abc import Mapping
 from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import (
     NetworkConfig,

--- a/plugins/cliconf/iosxr.py
+++ b/plugins/cliconf/iosxr.py
@@ -192,9 +192,10 @@ EXAMPLES = """
 import json
 import re
 
+from collections.abc import Mapping
+
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils.common.text.converters import to_text
-from collections.abc import Mapping
 from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import (
     NetworkConfig,

--- a/plugins/module_utils/network/iosxr/facts/acls/acls.py
+++ b/plugins/module_utils/network/iosxr/facts/acls/acls.py
@@ -20,7 +20,7 @@ import re
 from collections import deque
 from copy import deepcopy
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils
 
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.acls.acls import (

--- a/plugins/module_utils/network/iosxr/iosxr.py
+++ b/plugins/module_utils/network/iosxr/iosxr.py
@@ -35,7 +35,7 @@ import re
 
 from difflib import Differ
 
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.module_utils.connection import Connection, ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.netconf import (
     NetconfConnection,

--- a/plugins/module_utils/network/iosxr/utils/utils.py
+++ b/plugins/module_utils/network/iosxr/utils/utils.py
@@ -477,6 +477,8 @@ def netmask_to_cidr(netmask):
 
 
 def warn_and_exit(module, result):
+    # Passing 'warnings' to exit_json is deprecated in ansible-core 2.23.
+    # Emit warnings via module.warn() and remove the key before exit.
     for warning in result.pop('warnings', []):
         module.warn(warning)
     module.exit_json(**result)

--- a/plugins/module_utils/network/iosxr/utils/utils.py
+++ b/plugins/module_utils/network/iosxr/utils/utils.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 from functools import total_ordering
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.common.network import is_masklen, to_netmask
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (

--- a/plugins/module_utils/network/iosxr/utils/utils.py
+++ b/plugins/module_utils/network/iosxr/utils/utils.py
@@ -474,3 +474,9 @@ def _coerce(other):
 def netmask_to_cidr(netmask):
     # convert netmask to cidr and returns the cidr notation
     return str(sum([bin(int(x)).count("1") for x in netmask.split(".")]))
+
+
+def warn_and_exit(module, result):
+    for warning in result.pop('warnings', []):
+        module.warn(warning)
+    module.exit_json(**result)

--- a/plugins/module_utils/network/iosxr/utils/utils.py
+++ b/plugins/module_utils/network/iosxr/utils/utils.py
@@ -12,9 +12,9 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 from functools import total_ordering
 
-from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.common.network import is_masklen, to_netmask
+from ansible.module_utils.common.text.converters import to_text
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     dict_diff,
     search_obj_in_list,
@@ -479,6 +479,6 @@ def netmask_to_cidr(netmask):
 def warn_and_exit(module, result):
     # Passing 'warnings' to exit_json is deprecated in ansible-core 2.23.
     # Emit warnings via module.warn() and remove the key before exit.
-    for warning in result.pop('warnings', []):
+    for warning in result.pop("warnings", []):
         module.warn(warning)
     module.exit_json(**result)

--- a/plugins/modules/iosxr_acls.py
+++ b/plugins/modules/iosxr_acls.py
@@ -2288,6 +2288,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.acls.acls import (
     AclsArgs,
 )
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.acls.acls import Acls
 
 
@@ -2312,7 +2313,7 @@ def main():
     )
 
     result = Acls(module).execute_module()
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/iosxr_acls.py
+++ b/plugins/modules/iosxr_acls.py
@@ -2288,8 +2288,10 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.acls.acls import (
     AclsArgs,
 )
-from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.acls.acls import Acls
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import (
+    warn_and_exit,
+)
 
 
 def main():

--- a/plugins/modules/iosxr_banner.py
+++ b/plugins/modules/iosxr_banner.py
@@ -113,7 +113,9 @@ from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.iosxr im
     is_netconf,
     load_config,
 )
-from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import (
+    warn_and_exit,
+)
 
 
 class ConfigBase(object):

--- a/plugins/modules/iosxr_banner.py
+++ b/plugins/modules/iosxr_banner.py
@@ -113,6 +113,7 @@ from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.iosxr im
     is_netconf,
     load_config,
 )
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 
 
 class ConfigBase(object):
@@ -278,7 +279,8 @@ def main():
     result = None
     if config_object is not None:
         result = config_object.run()
-    module.exit_json(**result)
+
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/iosxr_command.py
+++ b/plugins/modules/iosxr_command.py
@@ -143,6 +143,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.p
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import to_lines
 
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.iosxr import run_commands
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 
 
 def parse_commands(module, warnings):
@@ -210,7 +211,7 @@ def main():
 
     result.update({"stdout": responses, "stdout_lines": list(to_lines(responses))})
 
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/iosxr_command.py
+++ b/plugins/modules/iosxr_command.py
@@ -135,7 +135,7 @@ failed_conditions:
 """
 import time
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.parsing import (
     Conditional,

--- a/plugins/modules/iosxr_command.py
+++ b/plugins/modules/iosxr_command.py
@@ -135,15 +135,17 @@ failed_conditions:
 """
 import time
 
-from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_text
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.parsing import (
     Conditional,
 )
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import to_lines
 
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.iosxr import run_commands
-from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import (
+    warn_and_exit,
+)
 
 
 def parse_commands(module, warnings):

--- a/plugins/modules/iosxr_config.py
+++ b/plugins/modules/iosxr_config.py
@@ -299,8 +299,8 @@ import os
 import re
 import tempfile
 
-from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import (
     NetworkConfig,
@@ -313,7 +313,9 @@ from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.iosxr im
     get_connection,
     load_config,
 )
-from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import (
+    warn_and_exit,
+)
 
 
 DEFAULT_COMMIT_COMMENT = "configured by iosxr_config"

--- a/plugins/modules/iosxr_config.py
+++ b/plugins/modules/iosxr_config.py
@@ -299,7 +299,7 @@ import os
 import re
 import tempfile
 
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import (

--- a/plugins/modules/iosxr_config.py
+++ b/plugins/modules/iosxr_config.py
@@ -313,6 +313,7 @@ from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.iosxr im
     get_connection,
     load_config,
 )
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 
 
 DEFAULT_COMMIT_COMMENT = "configured by iosxr_config"
@@ -529,7 +530,7 @@ def main():
         else:
             result["warnings"] = msg
 
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/iosxr_facts.py
+++ b/plugins/modules/iosxr_facts.py
@@ -215,7 +215,11 @@ def main():
     ansible_facts.update(additional_facts)
     warnings.extend(additional_warnings)
 
-    module.exit_json(ansible_facts=ansible_facts, warnings=warnings)
+    # Emit each warning using module.warn()
+    for warning in warnings:
+        module.warn(warning)
+
+    module.exit_json(ansible_facts=ansible_facts)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/iosxr_interfaces.py
+++ b/plugins/modules/iosxr_interfaces.py
@@ -593,9 +593,11 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.interfaces.interfaces import (
     InterfacesArgs,
 )
-from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.interfaces.interfaces import (
     Interfaces,
+)
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import (
+    warn_and_exit,
 )
 
 

--- a/plugins/modules/iosxr_interfaces.py
+++ b/plugins/modules/iosxr_interfaces.py
@@ -593,6 +593,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.interfaces.interfaces import (
     InterfacesArgs,
 )
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.interfaces.interfaces import (
     Interfaces,
 )
@@ -619,7 +620,7 @@ def main():
     )
 
     result = Interfaces(module).execute_module()
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/iosxr_l2_interfaces.py
+++ b/plugins/modules/iosxr_l2_interfaces.py
@@ -682,9 +682,11 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.l2_interfaces.l2_interfaces import (
     L2_InterfacesArgs,
 )
-from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.l2_interfaces.l2_interfaces import (
     L2_Interfaces,
+)
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import (
+    warn_and_exit,
 )
 
 

--- a/plugins/modules/iosxr_l2_interfaces.py
+++ b/plugins/modules/iosxr_l2_interfaces.py
@@ -682,6 +682,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.l2_interfaces.l2_interfaces import (
     L2_InterfacesArgs,
 )
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.l2_interfaces.l2_interfaces import (
     L2_Interfaces,
 )
@@ -708,7 +709,7 @@ def main():
     )
 
     result = L2_Interfaces(module).execute_module()
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/iosxr_l3_interfaces.py
+++ b/plugins/modules/iosxr_l3_interfaces.py
@@ -897,6 +897,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.l3_interfaces.l3_interfaces import (
     L3_InterfacesArgs,
 )
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.l3_interfaces.l3_interfaces import (
     L3_Interfaces,
 )
@@ -924,7 +925,7 @@ def main():
     )
 
     result = L3_Interfaces(module).execute_module()
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/iosxr_l3_interfaces.py
+++ b/plugins/modules/iosxr_l3_interfaces.py
@@ -897,9 +897,11 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.l3_interfaces.l3_interfaces import (
     L3_InterfacesArgs,
 )
-from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.l3_interfaces.l3_interfaces import (
     L3_Interfaces,
+)
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import (
+    warn_and_exit,
 )
 
 

--- a/plugins/modules/iosxr_lacp.py
+++ b/plugins/modules/iosxr_lacp.py
@@ -358,6 +358,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.lacp.lacp import (
     LacpArgs,
 )
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.lacp.lacp import Lacp
 
 
@@ -383,7 +384,7 @@ def main():
     )
 
     result = Lacp(module).execute_module()
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/iosxr_lacp.py
+++ b/plugins/modules/iosxr_lacp.py
@@ -358,8 +358,10 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.lacp.lacp import (
     LacpArgs,
 )
-from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.lacp.lacp import Lacp
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import (
+    warn_and_exit,
+)
 
 
 def main():

--- a/plugins/modules/iosxr_lacp_interfaces.py
+++ b/plugins/modules/iosxr_lacp_interfaces.py
@@ -616,6 +616,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.lacp_interfaces.lacp_interfaces import (
     Lacp_interfacesArgs,
 )
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.lacp_interfaces.lacp_interfaces import (
     Lacp_interfaces,
 )
@@ -644,7 +645,7 @@ def main():
     )
 
     result = Lacp_interfaces(module).execute_module()
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/iosxr_lacp_interfaces.py
+++ b/plugins/modules/iosxr_lacp_interfaces.py
@@ -616,9 +616,11 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.lacp_interfaces.lacp_interfaces import (
     Lacp_interfacesArgs,
 )
-from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.lacp_interfaces.lacp_interfaces import (
     Lacp_interfaces,
+)
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import (
+    warn_and_exit,
 )
 
 

--- a/plugins/modules/iosxr_lag_interfaces.py
+++ b/plugins/modules/iosxr_lag_interfaces.py
@@ -817,6 +817,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.lag_interfaces.lag_interfaces import (
     Lag_interfacesArgs,
 )
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.lag_interfaces.lag_interfaces import (
     Lag_interfaces,
 )
@@ -845,7 +846,7 @@ def main():
     )
 
     result = Lag_interfaces(module).execute_module()
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/iosxr_lag_interfaces.py
+++ b/plugins/modules/iosxr_lag_interfaces.py
@@ -817,9 +817,11 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.lag_interfaces.lag_interfaces import (
     Lag_interfacesArgs,
 )
-from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.lag_interfaces.lag_interfaces import (
     Lag_interfaces,
+)
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import (
+    warn_and_exit,
 )
 
 

--- a/plugins/modules/iosxr_lldp_global.py
+++ b/plugins/modules/iosxr_lldp_global.py
@@ -455,6 +455,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.lldp_global.lldp_global import (
     Lldp_globalArgs,
 )
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.lldp_global.lldp_global import (
     Lldp_global,
 )
@@ -481,7 +482,7 @@ def main():
     )
 
     result = Lldp_global(module).execute_module()
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/iosxr_lldp_global.py
+++ b/plugins/modules/iosxr_lldp_global.py
@@ -455,9 +455,11 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.lldp_global.lldp_global import (
     Lldp_globalArgs,
 )
-from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.lldp_global.lldp_global import (
     Lldp_global,
+)
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import (
+    warn_and_exit,
 )
 
 

--- a/plugins/modules/iosxr_lldp_interfaces.py
+++ b/plugins/modules/iosxr_lldp_interfaces.py
@@ -693,9 +693,11 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.lldp_interfaces.lldp_interfaces import (
     Lldp_interfacesArgs,
 )
-from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.lldp_interfaces.lldp_interfaces import (
     Lldp_interfaces,
+)
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import (
+    warn_and_exit,
 )
 
 

--- a/plugins/modules/iosxr_lldp_interfaces.py
+++ b/plugins/modules/iosxr_lldp_interfaces.py
@@ -693,6 +693,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.lldp_interfaces.lldp_interfaces import (
     Lldp_interfacesArgs,
 )
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.lldp_interfaces.lldp_interfaces import (
     Lldp_interfaces,
 )
@@ -720,7 +721,7 @@ def main():
     )
 
     result = Lldp_interfaces(module).execute_module()
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/iosxr_netconf.py
+++ b/plugins/modules/iosxr_netconf.py
@@ -82,7 +82,9 @@ from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.iosxr im
     get_config,
     load_config,
 )
-from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import (
+    warn_and_exit,
+)
 
 
 USE_PERSISTENT_CONNECTION = True

--- a/plugins/modules/iosxr_netconf.py
+++ b/plugins/modules/iosxr_netconf.py
@@ -82,6 +82,7 @@ from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.iosxr im
     get_config,
     load_config,
 )
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 
 
 USE_PERSISTENT_CONNECTION = True
@@ -198,7 +199,7 @@ def main():
             result["diff"] = dict(prepared=diff)
         result["changed"] = True
 
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/iosxr_ping.py
+++ b/plugins/modules/iosxr_ping.py
@@ -157,8 +157,10 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.ping.ping import (
     PingArgs,
 )
-from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.ping.ping import Ping
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import (
+    warn_and_exit,
+)
 
 
 def main():

--- a/plugins/modules/iosxr_ping.py
+++ b/plugins/modules/iosxr_ping.py
@@ -157,6 +157,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.ping.ping import (
     PingArgs,
 )
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.ping.ping import Ping
 
 
@@ -169,7 +170,7 @@ def main():
     module = AnsibleModule(argument_spec=PingArgs.argument_spec)
 
     result = Ping(module).execute_module()
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/iosxr_static_routes.py
+++ b/plugins/modules/iosxr_static_routes.py
@@ -1317,6 +1317,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.static_routes.static_routes import (
     Static_routesArgs,
 )
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.static_routes.static_routes import (
     Static_routes,
 )
@@ -1344,7 +1345,7 @@ def main():
     )
 
     result = Static_routes(module).execute_module()
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/iosxr_static_routes.py
+++ b/plugins/modules/iosxr_static_routes.py
@@ -1317,9 +1317,11 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.argspec.static_routes.static_routes import (
     Static_routesArgs,
 )
-from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.config.static_routes.static_routes import (
     Static_routes,
+)
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import (
+    warn_and_exit,
 )
 
 

--- a/plugins/modules/iosxr_system.py
+++ b/plugins/modules/iosxr_system.py
@@ -167,6 +167,7 @@ from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.iosxr im
     is_netconf,
     load_config,
 )
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
 
 
 def diff_list(want, have):
@@ -741,7 +742,8 @@ def main():
     result = None
     if config_object:
         result = config_object.run()
-    module.exit_json(**result)
+
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/iosxr_system.py
+++ b/plugins/modules/iosxr_system.py
@@ -167,7 +167,9 @@ from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.iosxr im
     is_netconf,
     load_config,
 )
-from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import warn_and_exit
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import (
+    warn_and_exit,
+)
 
 
 def diff_list(want, have):

--- a/plugins/modules/iosxr_user.py
+++ b/plugins/modules/iosxr_user.py
@@ -301,7 +301,7 @@ from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.iosxr im
     is_netconf,
     load_config,
 )
-from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import Version
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import Version, warn_and_exit
 
 
 try:
@@ -903,7 +903,7 @@ def main():
         pubkey_object = PublicKeyManager(module, result)
         result = pubkey_object.run()
 
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/iosxr_user.py
+++ b/plugins/modules/iosxr_user.py
@@ -301,7 +301,10 @@ from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.iosxr im
     is_netconf,
     load_config,
 )
-from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import Version, warn_and_exit
+from ansible_collections.cisco.iosxr.plugins.module_utils.network.iosxr.utils.utils import (
+    Version,
+    warn_and_exit,
+)
 
 
 try:

--- a/plugins/netconf/iosxr.py
+++ b/plugins/netconf/iosxr.py
@@ -45,7 +45,7 @@ import json
 import re
 
 from ansible.errors import AnsibleConnectionFailure
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.netconf import (
     remove_namespaces,
 )

--- a/tests/unit/mock/loader.py
+++ b/tests/unit/mock/loader.py
@@ -24,7 +24,7 @@ __metaclass__ = type
 import os
 
 from ansible.errors import AnsibleParserError
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.parsing.dataloader import DataLoader
 
 

--- a/tests/unit/mock/procenv.py
+++ b/tests/unit/mock/procenv.py
@@ -28,7 +28,7 @@ import sys
 from contextlib import contextmanager
 from io import BytesIO, StringIO
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 from ansible_collections.cisco.iosxr.tests.unit.compat import unittest
 

--- a/tests/unit/mock/vault_helper.py
+++ b/tests/unit/mock/vault_helper.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.parsing.vault import VaultSecret
 
 

--- a/tests/unit/modules/conftest.py
+++ b/tests/unit/modules/conftest.py
@@ -9,8 +9,8 @@ import json
 
 import pytest
 
-from ansible.module_utils._text import to_bytes
-from ansible.module_utils.common._collections_compat import MutableMapping
+from ansible.module_utils.common.text.converters import to_bytes
+from collections.abc import MutableMapping
 
 
 string_types = (str,)

--- a/tests/unit/modules/conftest.py
+++ b/tests/unit/modules/conftest.py
@@ -7,10 +7,11 @@ __metaclass__ = type
 
 import json
 
+from collections.abc import MutableMapping
+
 import pytest
 
 from ansible.module_utils.common.text.converters import to_bytes
-from collections.abc import MutableMapping
 
 
 string_types = (str,)

--- a/tests/unit/modules/network/iosxr/test_iosxr.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr.py
@@ -25,7 +25,7 @@ from os import path
 from unittest import TestCase
 from unittest.mock import MagicMock
 
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 
 from ansible_collections.cisco.iosxr.plugins.cliconf import iosxr
 

--- a/tests/unit/modules/network/iosxr/test_iosxr_n540.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_n540.py
@@ -25,7 +25,7 @@ from os import path
 from unittest import TestCase
 from unittest.mock import MagicMock
 
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 
 from ansible_collections.cisco.iosxr.plugins.cliconf import iosxr
 

--- a/tests/unit/modules/network/iosxr/test_iosxr_xrd.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_xrd.py
@@ -26,7 +26,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock
 
 from ansible.errors import AnsibleConnectionFailure
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 
 from ansible_collections.cisco.iosxr.plugins.cliconf import iosxr
 

--- a/tests/unit/modules/utils.py
+++ b/tests/unit/modules/utils.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from ansible.module_utils import basic
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 
 cur_context = None


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- **What is being changed?**
- Remediate the deprecated ansible.module utils dependencies
- **Why is this change needed?**
- We received the deprecation warning for the dependencies that will be removed in 2.23 and 2.24 versions respectively. Hence this change was needed
- **How does this change address the issue?**
- Replaced the older dependencies with recommended dependencies to resolve the warning

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New module (adding a new module to the collection)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [x] Refactoring (no functional changes)
- [ ] Collection release
- [ ] CI maintenance
- [ ] Workflow maintenance
- [ ] Configuration change

## Related Issue
<!-- Optional: Link to related issue(s) -->
- Fixes #
- Related to #

## Component Name
<!-- Mandatory: Specify the module, plugin, or component being changed -->
iosxr
<!-- Examples: iosxr_config, iosxr_bgp_global, cliconf plugin, terminal plugin, etc. -->

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have removed all commented code (no commented code should be merged)
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment
- [x] I have verified the changes work with the target IOS-XR version(s)
- [x] I have reviewed the acceptance criteria for related tickets

## Testing Instructions
<!-- Mandatory for all changes: Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required (e.g., IOS-XR version, hardware platform, test topology) -->
- IOS-XR Version:
- Hardware Platform (if applicable):
- Test Topology:

### Steps to Test
1. Ran unit test
2. Ran Integration tests

### Expected Results
<!-- Describe what should happen after following the steps -->

### Test Results
<!-- Paste test output or describe test results -->
```
```

## Acceptance Criteria Verification
<!-- Mandatory: Verify that all acceptance criteria from the related ticket are met -->
- [x] All acceptance criteria have been reviewed and verified
- [x] Acceptance criteria checklist:
  - [x] Replace ansible.module_utils.common._collections_compat with collections.abc
  - [x] Replace imports from ansible.module_utils._text with ansible.module_utils.common.text.converters
  - [x] Replace ansible.module_utils.six with native Python 3 equivalents
  - [x] All unit and integration tests pass
  - [x] No deprecation warnings when running with ansible-core 2.20+

## Additional Context
<!-- Optional but helpful information -->
<!-- Include additional information to help people understand the change here -->
<!-- A step-by-step reproduction of the problem is helpful if there is no related issue -->

### Command Output / Logs
<!-- Paste verbatim command output below, e.g. before and after your change -->
```
<!-- Paste below -->
```

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- Module documentation, examples, platform guides -->
- [ ] Requires changelog fragment
  <!-- Create changelog fragment if this is a user-facing change -->
- [ ] Requires integration test updates
- [ ] Requires unit test updates
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
<img width="724" height="524" alt="Screenshot 2026-06-29 at 12 59 14 PM" src="https://github.com/user-attachments/assets/c0f4a753-67a9-4534-ade3-cc2095dcbe45" />

<!-- Include device output, error messages, or test results -->

