### PR TITLE
iosxr_bgp_global/bgp_templates | Fix bmp_activate.server compval typo causing silent no-op

### DIFF
--- a/changelogs/fragments/bgp-bmp-activate-server-compval-fix.yml
+++ b/changelogs/fragments/bgp-bmp-activate-server-compval-fix.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - iosxr_bgp_global - Fixed compval typo 'bmp_activate.serevr' - 'bmp_activate.server'
+    that caused bmp-activate server configuration under neighbors to be a silent no-op.
+  - iosxr_bgp_templates - Fixed same compval typo in the neighbor-group context,
+    ensuring bmp-activate server is correctly generated for template-group neighbors.

--- a/plugins/module_utils/network/iosxr/rm_templates/bgp_global.py
+++ b/plugins/module_utils/network/iosxr/rm_templates/bgp_global.py
@@ -1529,7 +1529,7 @@ class Bgp_globalTemplate(NetworkTemplate):
                 $""", re.VERBOSE,
             ),
             "setval": "bmp-activate server {{bmp_activate.server}}",
-            "compval": "bmp_activate.serevr",
+            "compval": "bmp_activate.server",
             "result": {
                 "vrfs": {
                     '{{ "vrf_" + vrf|d() }}': {

--- a/plugins/module_utils/network/iosxr/rm_templates/bgp_templates.py
+++ b/plugins/module_utils/network/iosxr/rm_templates/bgp_templates.py
@@ -1298,7 +1298,7 @@ class Bgp_templatesTemplate(NetworkTemplate):
                 $""", re.VERBOSE,
             ),
             "setval": "bmp-activate server {{bmp_activate.server}}",
-            "compval": "bmp_activate.serevr",
+            "compval": "bmp_activate.server",
             "result": {
                 "neighbor": {
                     UNIQUE_NEIB_ADD: {

--- a/tests/integration/targets/iosxr_bgp_global/tests/common/merged.yaml
+++ b/tests/integration/targets/iosxr_bgp_global/tests/common/merged.yaml
@@ -96,3 +96,58 @@
           - '"no shutdown" in result.commands'
   always:
     - ansible.builtin.include_tasks: _remove_config.yaml
+
+# --- bmp_activate.server merged (requires BMP server pre-configured) ---
+- block:
+    - name: Setup BMP server 1 with host/port (device prerequisite for bmp-activate)
+      cisco.iosxr.iosxr_config:
+        lines:
+          - "host 1.2.3.4 port 12345"
+        parents:
+          - "bmp server 1"
+
+    - name: Merge neighbor with bmp_activate.server 1 — expect changed
+      cisco.iosxr.iosxr_bgp_global: &bmp_activate_id
+        config:
+          as_number: 65536
+          neighbors:
+            - neighbor: 192.0.2.11
+              remote_as: 65537
+              bmp_activate:
+                server: 1
+        state: merged
+      register: result
+
+    - name: Assert bmp-activate server 1 was generated
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - '"bmp-activate server 1" in result.commands'
+
+    - name: Merge same config again (idempotent)
+      cisco.iosxr.iosxr_bgp_global: *bmp_activate_id
+      register: result
+
+    - name: Assert idempotent run did not change
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.commands | length == 0
+
+  always:
+    - name: Cleanup — remove bmp-activate from neighbor
+      cisco.iosxr.iosxr_config:
+        lines:
+          - "no bmp-activate server 1"
+        parents:
+          - "router bgp 65536"
+          - "neighbor 192.0.2.11"
+      ignore_errors: true
+
+    - name: Cleanup — remove BMP server 1
+      cisco.iosxr.iosxr_config:
+        lines:
+          - "no bmp server 1"
+      ignore_errors: true
+
+    - ansible.builtin.include_tasks: _remove_config.yaml

--- a/tests/unit/modules/network/iosxr/test_iosxr_bgp_global.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_bgp_global.py
@@ -149,6 +149,38 @@ class TestIosxrBgpGlobalModule(TestIosxrModule):
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(commands))
 
+    def test_iosxr_bgp_global_merged_neighbor_bmp_activate(self):
+        run_cfg = dedent(
+            """\
+            router bgp 65536
+              neighbor 192.0.2.11
+                remote-as 65537
+            """,
+        )
+        self.get_config.return_value = run_cfg
+        set_module_args(
+            dict(
+                config=dict(
+                    as_number="65536",
+                    neighbors=[
+                        dict(
+                            neighbor_address="192.0.2.11",
+                            remote_as="65537",
+                            bmp_activate=dict(server=1),
+                        ),
+                    ],
+                ),
+                state="merged",
+            ),
+        )
+        commands = [
+            "router bgp 65536",
+            "neighbor 192.0.2.11",
+            "bmp-activate server 1",
+        ]
+        result = self.execute_module(changed=True)
+        self.assertEqual(sorted(result["commands"]), sorted(commands))
+
     def test_iosxr_bgp_global_merged(self):
         set_module_args(
             dict(


### PR DESCRIPTION
## Description

- **What:** Fix one-character typo in `compval` for the `bmp_activate` parser — `'bmp_activate.serevr'` → `'bmp_activate.server'` — in both `bgp_global.py` and `bgp_templates.py`.
- **Why:** The misspelled comparison path never resolved against the argspec dict, so `bmp-activate server <N>` was silently dropped from generated commands regardless of desired state. Any playbook configuring `bmp_activate.server` under a neighbor or neighbor-group was a no-op.
- **How:** One-character correction to the `compval` string in each file. No logic changes; `getval`/`setval`/`result` were already correct.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update

## Related Issue

- Fixes #

## Component Name

`cisco.iosxr.iosxr_bgp_global`, `cisco.iosxr.iosxr_bgp_templates`

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have removed all commented code
- [x] I have tested the changes in my local environment
- [x] I have verified the changes work with the target IOS-XR version(s)

## Testing Instructions

### Prerequisites

- IOS-XR device reachable via network_cli
- BMP server must be configured with `bmp server 1 / host <ip> port <port>` before `bmp-activate server 1` is accepted by the device

### Steps to Test

1. Without fix: render a neighbor config with `bmp_activate.server: 1` — command absent from output
2. Apply fix
3. Render same config — `bmp-activate server 1` present
4. Run merged state on device — `changed: true`, command applied
5. Re-run — `changed: false` (idempotent)

### Expected Results

`bmp-activate server <N>` appears in rendered and merged command output when `bmp_activate.server` is set in config.

## Command Output / Logs

### Before (broken)

```
TASK [Render config — bmp-activate server 1 must appear in rendered output]
ok: [iosxr-cli] => {
    "result.rendered": [
        "router bgp 65536",
        "neighbor 192.0.2.11",
        "remote-as 65537"
    ]
}
TASK [Assert bmp-activate server 1 is in rendered output]
fatal: BUG: compval typo 'bmp_activate.serevr' — bmp-activate server 1 not generated.
rendered=['router bgp 65536', 'neighbor 192.0.2.11', 'remote-as 65537']
```

### After (fixed)

```
TASK [Render config — bmp-activate server 1 must appear in rendered output]
ok: [iosxr-cli] => {
    "result.rendered": [
        "router bgp 65536",
        "neighbor 192.0.2.11",
        "bmp-activate server 1",
        "remote-as 65537"
    ]
}
TASK [Assert bmp-activate server 1 is in rendered output]
ok: PASS: bmp-activate server 1 found in rendered output

TASK [Apply bmp_activate.server 1 via iosxr_bgp_global merged]
changed: [iosxr-cli] => {
    "changed": true,
    "commands": [
        "router bgp 65536",
        "neighbor 192.0.2.11",
        "bmp-activate server 1"
    ]
}
TASK [Assert idempotent (changed=false)]
ok: PASS: idempotent on second run
```

### Unit tests

```
tox -e unit-py3.11-2.19 -- tests/unit/modules/network/iosxr/test_iosxr_bgp_global.py
356 passed in 8.28s
```

## Required Actions

- [x] Requires changelog fragment
- [x] Requires integration test updates
- [x] Requires unit test updates