### PR TITLE
Remove pycrypto from requirements.txt for unit tests

### DIFF
--- a/changelogs/fragments/remove_pycrypto_unit_requirements.yml
+++ b/changelogs/fragments/remove_pycrypto_unit_requirements.yml
@@ -1,0 +1,2 @@
+trivial:
+  - Remove unused pycrypto from unit test requirements.

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,6 +1,5 @@
 boto3
 placebo
-pycrypto
 passlib
 pypsrp
 python-memcached


### PR DESCRIPTION
## Description
- Why is this change needed?
Unit Test CI Jobs are failing because of pycrypto being built (unmaintained; fails on newer Python).

Same fix as https://github.com/ansible-collections/cisco.nxos/pull/1083 — `pycrypto` is listed in `tests/unit/requirements.txt` but is not used by this collection.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New module (adding a new module to the collection)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Collection release
- [x] CI maintenance
- [ ] Workflow maintenance
- [ ] Configuration change

## Test plan
- [ ] Confirm unit-test CI no longer fails installing pycrypto
- [x] Verified no `Crypto` / pycrypto imports in collection code