### PR TITLE
Fix bgp_neighbor_address_family default-originate fact gather crash

### DIFF
--- a/changelogs/fragments/aap83883_default_originate.yml
+++ b/changelogs/fragments/aap83883_default_originate.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - iosxr_bgp_neighbor_address_family - Fix fact gathering crash when neighbors
+    use ``default-originate route-policy`` or ``default-originate inheritance-disable``
+    by only setting ``set`` for the bare ``default-originate`` form.

--- a/plugins/module_utils/network/iosxr/rm_templates/bgp_neighbor_address_family.py
+++ b/plugins/module_utils/network/iosxr/rm_templates/bgp_neighbor_address_family.py
@@ -116,15 +116,15 @@ def _tmpl_remove_private_AS(config_data):
 
 def _tmpl_default_originate(config_data):
     conf = config_data.get("default_originate", {})
-    command = ""
-    if conf:
-        if "set" in conf:
-            command = "default-originate"
-        if "inheritance_disable" in conf:
-            command = "default-originate inheritance-disable"
-        if "route_policy" in conf:
-            command = "default-originate route_policy " + conf["route_policy"]
-    return command
+    if not conf:
+        return ""
+    if conf.get("set"):
+        return "default-originate"
+    if conf.get("inheritance_disable"):
+        return "default-originate inheritance-disable"
+    if conf.get("route_policy"):
+        return "default-originate route-policy " + conf["route_policy"]
+    return ""
 
 
 class Bgp_neighbor_address_familyTemplate(NetworkTemplate):
@@ -357,7 +357,7 @@ class Bgp_neighbor_address_familyTemplate(NetworkTemplate):
                                 "address_family": {
                                     '{{"address_family_" + afi + "_" + safi}}': {
                                         "default_originate": {
-                                            "set": "{{True if default_originate is defined}}",
+                                            "set": "{{True if default_originate is defined and route_policy is not defined and inheritance_disable is not defined}}",
                                             "route_policy": "{{route_policy}}",
                                             "inheritance_disable": "{{True if inheritance_disable is defined}}",
                                         },

--- a/plugins/module_utils/network/iosxr/rm_templates/bgp_neighbor_address_family.py
+++ b/plugins/module_utils/network/iosxr/rm_templates/bgp_neighbor_address_family.py
@@ -357,7 +357,9 @@ class Bgp_neighbor_address_familyTemplate(NetworkTemplate):
                                 "address_family": {
                                     '{{"address_family_" + afi + "_" + safi}}': {
                                         "default_originate": {
-                                            "set": "{{True if default_originate is defined and route_policy is not defined and inheritance_disable is not defined}}",
+                                            "set": "{{True if default_originate is defined "
+                                                   "and route_policy is not defined "
+                                                   "and inheritance_disable is not defined}}",
                                             "route_policy": "{{route_policy}}",
                                             "inheritance_disable": "{{True if inheritance_disable is defined}}",
                                         },

--- a/tests/unit/modules/network/iosxr/test_iosxr_bgp_neighbor_address_family.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_bgp_neighbor_address_family.py
@@ -824,3 +824,86 @@ class TestIosxrBgpNeighborAddressFamilyModule(TestIosxrModule):
         ]
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(commands))
+
+    def test_iosxr_bgp_nbr_af_default_originate_forms_parsed(self):
+        """Mixed default-originate forms must parse without mutual exclusivity errors."""
+        self.maxDiff = None
+        set_module_args(
+            dict(
+                running_config=dedent(
+                    """\
+                    router bgp 65137
+                     vrf VRF-A
+                      neighbor 192.0.2.1
+                       address-family ipv4 unicast
+                        default-originate route-policy MY-POLICY
+                       !
+                      !
+                     !
+                     vrf VRF-B
+                      neighbor 192.0.2.2
+                       address-family ipv4 unicast
+                        default-originate
+                       !
+                      !
+                     !
+                     neighbor 192.0.2.3
+                      address-family ipv4 unicast
+                       default-originate inheritance-disable
+                      !
+                     !
+                    !
+                    """,
+                ),
+                state="parsed",
+            ),
+        )
+        result = self.execute_module(changed=False)
+        parsed_list = {
+            "as_number": "65137",
+            "neighbors": [
+                {
+                    "neighbor_address": "192.0.2.3",
+                    "address_family": [
+                        {
+                            "afi": "ipv4",
+                            "safi": "unicast",
+                            "default_originate": {"inheritance_disable": True},
+                        },
+                    ],
+                },
+            ],
+            "vrfs": [
+                {
+                    "vrf": "VRF-A",
+                    "neighbors": [
+                        {
+                            "neighbor_address": "192.0.2.1",
+                            "address_family": [
+                                {
+                                    "afi": "ipv4",
+                                    "safi": "unicast",
+                                    "default_originate": {"route_policy": "MY-POLICY"},
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    "vrf": "VRF-B",
+                    "neighbors": [
+                        {
+                            "neighbor_address": "192.0.2.2",
+                            "address_family": [
+                                {
+                                    "afi": "ipv4",
+                                    "safi": "unicast",
+                                    "default_originate": {"set": True},
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        }
+        self.assertEqual(parsed_list, result["parsed"])


### PR DESCRIPTION
## Summary

Fixes fact gathering / parsed-state crashes in `iosxr_bgp_neighbor_address_family` when a neighbor uses `default-originate route-policy <NAME>` or `default-originate inheritance-disable` (AAP-83883).

> Note: the customer report titled this as `bgp_global`, but the failing path is `config -> vrfs -> neighbors -> address_family -> default_originate`, which belongs to **bgp_neighbor_address_family**.

## What was going wrong

`default_originate` is mutually exclusive in the argspec: only one of `set`, `route_policy`, or `inheritance_disable` is allowed.

The single parser matched all CLI forms, but the result mapping always set `set: True` whenever the line contained `default-originate`:

```python
"set": "{{True if default_originate is defined}}"
```

`(?P<default_originate>)` is a zero-width group that is always defined on match, so a policy line was parsed as:

```json
{"set": true, "route_policy": "MY-POLICY"}
```

That violates mutual exclusivity and `validate_config` aborts fact gathering.

### Example

Device config:

```text
router bgp 65137
 vrf VRF-A
  neighbor 192.0.2.1
   address-family ipv4 unicast
    default-originate route-policy MY-POLICY
 vrf VRF-B
  neighbor 192.0.2.2
   address-family ipv4 unicast
    default-originate
```

Before this fix:

```text
parameters are mutually exclusive: set|route_policy|inheritance_disable
found in config -> vrfs -> neighbors -> address_family -> default_originate
```

## What we changed

Kept **one reader**, and made the result mapping exclusive (same pattern used elsewhere, e.g. `allowas_in`):

```python
"set": "{{True if default_originate is defined and route_policy is not defined and inheritance_disable is not defined}}"
```

So:

| CLI | Parsed fact |
|---|---|
| `default-originate` | `{"set": true}` |
| `default-originate route-policy MY-POLICY` | `{"route_policy": "MY-POLICY"}` |
| `default-originate inheritance-disable` | `{"inheritance_disable": true}` |

Also fixed `_tmpl_default_originate` setval to emit valid IOS-XR CLI (`route-policy` with a hyphen) using exclusive branches.

## How this solves it

Each CLI form now maps to exactly one argspec key, so mutual exclusivity validation passes and fact gathering / `state: parsed` succeed for mixed neighbor configs.

## Reproduction results (before / after)

Live lab repro against the same customer scenario (mixed VRF neighbors: bare `default-originate` + `default-originate route-policy MY-POLICY`).

Config pushed to device (lab ASN `65138`; same structure as the ticket):

```text
router bgp 65138
 vrf VRF-A
  neighbor 192.0.2.1
   address-family ipv4 unicast
    default-originate route-policy MY-POLICY
 vrf VRF-B
  neighbor 192.0.2.2
   address-family ipv4 unicast
    default-originate
```

### Before (broken reader)

Fact gather / parse failed:

```text
TASK [Gather via iosxr_bgp_neighbor_address_family] ****************************
fatal: [xr1]: FAILED! => {
  "msg": "parameters are mutually exclusive: set|route_policy|inheritance_disable found in config -> vrfs -> neighbors -> address_family -> default_originate"
}
```

What the old reader produced for the policy form (illegal):

```json
{
  "set": true,
  "route_policy": "MY-POLICY"
}
```

### After (this PR — single reader, exclusive mapping)

Same config on device; gather succeeds via both paths:

1. `cisco.iosxr.iosxr_bgp_neighbor_address_family: state=gathered`
2. `cisco.iosxr.iosxr_facts` with `gather_network_resources: [bgp_neighbor_address_family]`

```json
{
  "as_number": "65138",
  "vrfs": [
    {
      "vrf": "VRF-A",
      "neighbors": [
        {
          "neighbor_address": "192.0.2.1",
          "address_family": [
            {
              "afi": "ipv4",
              "safi": "unicast",
              "default_originate": {
                "route_policy": "MY-POLICY"
              }
            }
          ]
        }
      ]
    },
    {
      "vrf": "VRF-B",
      "neighbors": [
        {
          "neighbor_address": "192.0.2.2",
          "address_family": [
            {
              "afi": "ipv4",
              "safi": "unicast",
              "default_originate": {
                "set": true
              }
            }
          ]
        }
      ]
    }
  ]
}
```

| Neighbor | CLI on device | Parsed after fix |
|---|---|---|
| VRF-A `192.0.2.1` | `default-originate route-policy MY-POLICY` | `{"route_policy": "MY-POLICY"}` only |
| VRF-B `192.0.2.2` | `default-originate` | `{"set": true}` only |

No mutual exclusivity error — the single reader now maps each form to exactly one field.

## Test plan

- [x] Unit: `test_iosxr_bgp_nbr_af_default_originate_forms_parsed` (mixed VRF bare + route-policy + inheritance-disable)
- [x] Full unit file for `test_iosxr_bgp_neighbor_address_family.py` (12 passed)
- [x] Live XR repro: push ticket mixed config, gather via module + `iosxr_facts` (before crash / after success)
- [x] Local sanity (`pep8` line-length fix included)
- [ ] CI unit / sanity on PR