### PR TITLE
Prep_release: IOSXR Minor release 12.5.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,15 +4,24 @@ Cisco Iosxr Collection Release Notes
 
 .. contents:: Topics
 
+v12.5.0
+=======
+
+Bugfixes
+--------
+
+- iosxr_bgp_neighbor_address_family - Fix fact gathering crash when neighbors use ``default-originate route-policy`` or ``default-originate inheritance-disable`` by only setting ``set`` for the bare ``default-originate`` form.
+- netconf - Parse large XML config strings with ``huge_tree=True`` in ``edit_config`` to prevent lxml from rejecting payloads exceeding the default 10MB text-node limit.
+
 v12.4.0
 =======
 
 Minor Changes
 -------------
 
-- Fixed for iosxr_lldp_interfaces, iosxr_lldp_global, iosxr_lag_interfaces, iosxr_lacp_interfaces, iosxr_lacp, iosxr_l3_interfaces, iosxr_l2_interfaces, iosxr_interfaces, iosxr_acls, iosxr_static_routes, iosxr_ping,iosxr_banner, iosxr_config, iosxr_system, iosxr_command, iosxr_user, iosxr_netconf
-- For iosxr_vrf_interfaces, iosxr_vrf_global, iosxr_vrf_address_family, iosxr_snmp_server, iosxr_route_maps, iosxr_prefix_lists, iosxr_ospfv3, iosxr_ospfv2, iosxr_ospf_interfaces, iosxr_ntp_global, iosxr_logging_global, iosxr_hostname, iosxr_bgp_templates, iosxr_bgp_neighbor_address_family, iosxr_bgp_global, iosxr_bgp_address_family, iosxr_acl_interfaces modules ,fix will be done via netcommon ResourceModule.result change (Upstream to iosxr)
-- No changes for fail_json since it uses msg format already , except for ping module where currently warning is not being set.
+- Fixed for iosxr_lldp_interfaces, iosxr_lldp_global, iosxr_lag_interfaces, iosxr_lacp_interfaces, iosxr_lacp, iosxr_l3_interfaces, iosxr_l2_interfaces, iosxr_interfaces, iosxr_acls, iosxr_static_routes, iosxr_ping, iosxr_banner, iosxr_config, iosxr_system, iosxr_command, iosxr_user, iosxr_netconf
+- For iosxr_vrf_interfaces, iosxr_vrf_global, iosxr_vrf_address_family, iosxr_snmp_server, iosxr_route_maps, iosxr_prefix_lists, iosxr_ospfv3, iosxr_ospfv2, iosxr_ospf_interfaces, iosxr_ntp_global, iosxr_logging_global, iosxr_hostname, iosxr_bgp_templates, iosxr_bgp_neighbor_address_family, iosxr_bgp_global, iosxr_bgp_address_family, iosxr_acl_interfaces modules, fix will be done via netcommon ResourceModule.result change (Upstream to iosxr)
+- No changes for fail_json since it uses msg format already, except for ping module where currently warning is not being set.
 - Remediate deprecated 'to_bytes' from 'ansible.module_utils._text' and replaced with ansible.module_utils.common.text.converters.
 - Remediate deprecated 'to_text' from 'ansible.module_utils._text' and replaced with ansible.module_utils.common.text.converters.
 - Remediate deprecated ``warnings`` parameter in ``exit_json`` calls by using ``AnsibleModule.warn()`` across all iosxr modules to address deprecation warning from ansible-core 2.23.

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -432,6 +432,19 @@ releases:
       - tox_skip_cleanup.yml
       - update_integration_libssh_multi_version.yaml
     release_date: "2026-07-20"
+  12.5.0:
+    changes:
+      bugfixes:
+        - iosxr_bgp_neighbor_address_family - Fix fact gathering crash when neighbors
+          use ``default-originate route-policy`` or ``default-originate inheritance-disable``
+          by only setting ``set`` for the bare ``default-originate`` form.
+        - netconf - Parse large XML config strings with ``huge_tree=True`` in ``edit_config``
+          to prevent lxml from rejecting payloads exceeding the default 10MB text-node
+          limit.
+    fragments:
+      - aap83883_default_originate.yml
+      - fix_edit_config_huge_tree.yaml
+    release_date: "2026-08-05"
   2.0.0:
     changes:
       bugfixes:

--- a/changelogs/fragments/aap83883_default_originate.yml
+++ b/changelogs/fragments/aap83883_default_originate.yml
@@ -1,4 +1,0 @@
-bugfixes:
-  - iosxr_bgp_neighbor_address_family - Fix fact gathering crash when neighbors
-    use ``default-originate route-policy`` or ``default-originate inheritance-disable``
-    by only setting ``set`` for the bare ``default-originate`` form.

--- a/changelogs/fragments/fix_edit_config_huge_tree.yaml
+++ b/changelogs/fragments/fix_edit_config_huge_tree.yaml
@@ -1,4 +1,0 @@
----
-bugfixes:
-  - "netconf - Parse large XML config strings with ``huge_tree=True`` in ``edit_config``
-    to prevent lxml from rejecting payloads exceeding the default 10MB text-node limit."

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,6 +13,6 @@ issues: https://github.com/ansible-collections/cisco.iosxr/issues
 tags: [cisco, iosxr, networking, netconf]
 # NOTE(pabelanger): We create an empty version key to keep ansible-galaxy
 # happy. We dynamically inject version info based on git information.
-version: "12.4.0"
+version: "12.5.0"
 build_ignore:
   - .ansible-lint


### PR DESCRIPTION
## Summary
- Branch based on latest `main` (`ac2364c`).
- Bump `galaxy.yml` version to **12.5.0** (minor).
- Generate changelog from pending fragments.

## Changelog highlights
- **Bugfixes:** `iosxr_bgp_neighbor_address_family` default-originate fact gather crash (#630 / AAP-83883).
- **Bugfixes:** netconf `edit_config` `huge_tree=True` for large XML payloads (#628).

## Test plan
- [ ] Confirm fragments directory only has `.keep`
- [ ] CI green on this PR
- [ ] After merge: tag `v12.5.0` and run **Release collection** (`workflow_dispatch`)