### PR TITLE
Fix iosxr_facts set med +N/-N parsing in route_maps

### DIFF
--- a/changelogs/fragments/fix_route_maps_set_med_parsing.yaml
+++ b/changelogs/fragments/fix_route_maps_set_med_parsing.yaml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - "route_maps - Fix ``set med +<N>`` / ``set med -<N>`` parsing in
+    ``Route_mapsTemplate`` so that incremental MED statements using
+    device-native attached-sign syntax are no longer silently skipped
+    during fact gathering."

--- a/docs/cisco.iosxr.iosxr_route_maps_module.rst
+++ b/docs/cisco.iosxr.iosxr_route_maps_module.rst
@@ -2175,6 +2175,7 @@ Parameters
                 </td>
                 <td>
                         <div>Metric for Equal-Cost Multi-Path</div>
+                        <div>Note: increment and decrement are mutually exclusive</div>
                 </td>
             </tr>
                                 <tr>
@@ -2195,6 +2196,7 @@ Parameters
                 </td>
                 <td>
                         <div>Decrement the metric value</div>
+                        <div>Mutually exclusive with increment</div>
                 </td>
             </tr>
             <tr>
@@ -2239,6 +2241,7 @@ Parameters
                 </td>
                 <td>
                         <div>Increment the metric value</div>
+                        <div>Mutually exclusive with decrement</div>
                 </td>
             </tr>
             <tr>
@@ -5512,6 +5515,7 @@ Parameters
                 </td>
                 <td>
                         <div>Metric for Equal-Cost Multi-Path</div>
+                        <div>Note: increment and decrement are mutually exclusive</div>
                 </td>
             </tr>
                                 <tr>
@@ -5532,6 +5536,7 @@ Parameters
                 </td>
                 <td>
                         <div>Decrement the metric value</div>
+                        <div>Mutually exclusive with increment</div>
                 </td>
             </tr>
             <tr>
@@ -5576,6 +5581,7 @@ Parameters
                 </td>
                 <td>
                         <div>Increment the metric value</div>
+                        <div>Mutually exclusive with decrement</div>
                 </td>
             </tr>
             <tr>
@@ -8830,6 +8836,7 @@ Parameters
                 </td>
                 <td>
                         <div>Metric for Equal-Cost Multi-Path</div>
+                        <div>Note: increment and decrement are mutually exclusive</div>
                 </td>
             </tr>
                                 <tr>
@@ -8850,6 +8857,7 @@ Parameters
                 </td>
                 <td>
                         <div>Decrement the metric value</div>
+                        <div>Mutually exclusive with increment</div>
                 </td>
             </tr>
             <tr>
@@ -8894,6 +8902,7 @@ Parameters
                 </td>
                 <td>
                         <div>Increment the metric value</div>
+                        <div>Mutually exclusive with decrement</div>
                 </td>
             </tr>
             <tr>
@@ -12166,6 +12175,7 @@ Parameters
                 </td>
                 <td>
                         <div>Metric for Equal-Cost Multi-Path</div>
+                        <div>Note: increment and decrement are mutually exclusive</div>
                 </td>
             </tr>
                                 <tr>
@@ -12186,6 +12196,7 @@ Parameters
                 </td>
                 <td>
                         <div>Decrement the metric value</div>
+                        <div>Mutually exclusive with increment</div>
                 </td>
             </tr>
             <tr>
@@ -12230,6 +12241,7 @@ Parameters
                 </td>
                 <td>
                         <div>Increment the metric value</div>
+                        <div>Mutually exclusive with decrement</div>
                 </td>
             </tr>
             <tr>
@@ -15404,6 +15416,7 @@ Parameters
                 </td>
                 <td>
                         <div>Metric for Equal-Cost Multi-Path</div>
+                        <div>Note: increment and decrement are mutually exclusive</div>
                 </td>
             </tr>
                                 <tr>
@@ -15423,6 +15436,7 @@ Parameters
                 </td>
                 <td>
                         <div>Decrement the metric value</div>
+                        <div>Mutually exclusive with increment</div>
                 </td>
             </tr>
             <tr>
@@ -15465,6 +15479,7 @@ Parameters
                 </td>
                 <td>
                         <div>Increment the metric value</div>
+                        <div>Mutually exclusive with decrement</div>
                 </td>
             </tr>
             <tr>
@@ -18568,6 +18583,7 @@ Parameters
                 </td>
                 <td>
                         <div>Metric for Equal-Cost Multi-Path</div>
+                        <div>Note: increment and decrement are mutually exclusive</div>
                 </td>
             </tr>
                                 <tr>
@@ -18587,6 +18603,7 @@ Parameters
                 </td>
                 <td>
                         <div>Decrement the metric value</div>
+                        <div>Mutually exclusive with increment</div>
                 </td>
             </tr>
             <tr>
@@ -18629,6 +18646,7 @@ Parameters
                 </td>
                 <td>
                         <div>Increment the metric value</div>
+                        <div>Mutually exclusive with decrement</div>
                 </td>
             </tr>
             <tr>
@@ -21749,6 +21767,7 @@ Parameters
                 </td>
                 <td>
                         <div>Metric for Equal-Cost Multi-Path</div>
+                        <div>Note: increment and decrement are mutually exclusive</div>
                 </td>
             </tr>
                                 <tr>
@@ -21768,6 +21787,7 @@ Parameters
                 </td>
                 <td>
                         <div>Decrement the metric value</div>
+                        <div>Mutually exclusive with increment</div>
                 </td>
             </tr>
             <tr>
@@ -21810,6 +21830,7 @@ Parameters
                 </td>
                 <td>
                         <div>Increment the metric value</div>
+                        <div>Mutually exclusive with decrement</div>
                 </td>
             </tr>
             <tr>
@@ -22989,6 +23010,56 @@ Examples
     #
     # viosxr#show running-config | include route-policy
     #
+
+    - name: Configure route-policy with MED (Metric for Equal-Cost Multi-Path)
+      cisco.iosxr.iosxr_route_maps:
+        state: merged
+        config:
+          - name: MED_INCREMENT_POLICY
+            global:
+              set:
+                med:
+                  increment: 50  # Increment MED by 50
+                  value: 50
+          - name: MED_DECREMENT_POLICY
+            global:
+              set:
+                med:
+                  decrement: 25  # Decrement MED by 25
+                  value: 25
+          - name: MED_STATIC_POLICY
+            global:
+              set:
+                med:
+                  value: 100  # Set MED to static value 100
+          - name: MED_IGP_COST_POLICY
+            global:
+              set:
+                med:
+                  igp_cost: true  # Set MED to IGP cost
+
+    # Note: increment and decrement are mutually exclusive.
+    # The following would result in an error:
+    #   med:
+    #     increment: 50
+    #     decrement: 50  # ERROR: Cannot specify both increment and decrement
+
+    # Task Output
+    # -----------
+    #
+    # commands:
+    # - route-policy MED_INCREMENT_POLICY
+    # - set med +50
+    # - end-policy
+    # - route-policy MED_DECREMENT_POLICY
+    # - set med -25
+    # - end-policy
+    # - route-policy MED_STATIC_POLICY
+    # - set med 100
+    # - end-policy
+    # - route-policy MED_IGP_COST_POLICY
+    # - set med igp-cost
+    # - end-policy
 
     - name: Merge route-policy configuration
       cisco.iosxr.iosxr_route_maps:

--- a/plugins/module_utils/network/iosxr/argspec/route_maps/route_maps.py
+++ b/plugins/module_utils/network/iosxr/argspec/route_maps/route_maps.py
@@ -225,6 +225,7 @@ class Route_mapsArgs(object):  # pylint: disable=R0903
                                         "max_reachable": {"type": "bool"},
                                         "parameter": {"type": "str"},  # like "$param1"
                                     },
+                                    "mutually_exclusive": [["increment", "decrement"]],
                                 },
                                 "metric_type": {
                                     "type": "dict",
@@ -506,6 +507,7 @@ class Route_mapsArgs(object):  # pylint: disable=R0903
                                         "max_reachable": {"type": "bool"},
                                         "parameter": {"type": "str"},  # like "$param1"
                                     },
+                                    "mutually_exclusive": [["increment", "decrement"]],
                                 },
                                 "mpls": {"type": "str"},
                                 "next_hop": {

--- a/plugins/module_utils/network/iosxr/rm_templates/route_maps.py
+++ b/plugins/module_utils/network/iosxr/rm_templates/route_maps.py
@@ -818,10 +818,12 @@ class Route_mapsTemplate(NetworkTemplate):
             "name": "set.med",
             "getval": re.compile(
                 r"""
-                \s*set\smed\s
+                \s*set\smed\s*
                 (?P<increment>\+)?
                 (?P<decrement>\-)?
+                \s*
                 (?P<value>\d+)?
+                \s*
                 (?P<igp_cost>igp-cost)?
                 (?P<max_reachable>max-reachable)?
                 (?P<parameter>\$\w+)?

--- a/plugins/module_utils/network/iosxr/rm_templates/route_maps.py
+++ b/plugins/module_utils/network/iosxr/rm_templates/route_maps.py
@@ -828,9 +828,10 @@ class Route_mapsTemplate(NetworkTemplate):
                 $""", re.VERBOSE,
             ),
             "setval": "set med"
-            "{{ ' +' if set.med.increment|d(False) else '' }}"
-            "{{ ' -' if set.med.decrement|d(False) else '' }}"
-            "{{ set.med.value|string if set.med.value is defined and (set.med.increment|d(False) or set.med.decrement|d(False)) else (' ' ~ set.med.value|string) if set.med.value is defined else '' }}"
+            "{{ ' +' ~ set.med.value|string if set.med.increment|d(False) and set.med.value is defined else '' }}"
+            "{{ ' -' ~ set.med.value|string if set.med.decrement|d(False) and set.med.value is defined else '' }}"
+            "{{ ' ' ~ set.med.value|string if set.med.value is defined and not set.med.increment|d(False)"
+            " and not set.med.decrement|d(False) else '' }}"
             "{{ ' igp-cost' if set.med.igp_cost|d(False) else '' }}"
             "{{ ' max-reachable' if set.med.max_reachable|d(False) else '' }}"
             "{{ (' ' ~ set.med.parameter) if set.med.parameter is defined else '' }}",

--- a/plugins/module_utils/network/iosxr/rm_templates/route_maps.py
+++ b/plugins/module_utils/network/iosxr/rm_templates/route_maps.py
@@ -818,22 +818,22 @@ class Route_mapsTemplate(NetworkTemplate):
             "name": "set.med",
             "getval": re.compile(
                 r"""
-                \s*set\smed
-                (\s(?P<increment>\+))?
-                (\s(?P<decrement>\-))?
-                (\s(?P<value>\d+))?
-                (\s(?P<igp_cost>igp-cost))?
-                (\s(?P<max_reachable>max-reachable))?
-                (\s(?P<parameter>\$\w+))?
+                \s*set\smed\s
+                (?P<increment>\+)?
+                (?P<decrement>\-)?
+                (?P<value>\d+)?
+                (?P<igp_cost>igp-cost)?
+                (?P<max_reachable>max-reachable)?
+                (?P<parameter>\$\w+)?
                 $""", re.VERBOSE,
             ),
             "setval": "set med"
-            "{{ (' +' ) if set.med.increment is defined else '' }}"
-            "{{ (' -' ) if set.med.decrement is defined else '' }}"
-            "{{ (' ' + set.med.value|string ) if set.med.value is defined else '' }}"
-            "{{ (' igp-cost') if set.med.igp_cost|d(False) else '' }}"
-            "{{ (' max-reachable') if set.med.max_reachable|d(False) else '' }}"
-            "{{ (' ' + set.med.parameter ) if set.med.parameter is defined else '' }}",
+            "{{ ' +' if set.med.increment|d(False) else '' }}"
+            "{{ ' -' if set.med.decrement|d(False) else '' }}"
+            "{{ set.med.value|string if set.med.value is defined and (set.med.increment|d(False) or set.med.decrement|d(False)) else (' ' ~ set.med.value|string) if set.med.value is defined else '' }}"
+            "{{ ' igp-cost' if set.med.igp_cost|d(False) else '' }}"
+            "{{ ' max-reachable' if set.med.max_reachable|d(False) else '' }}"
+            "{{ (' ' ~ set.med.parameter) if set.med.parameter is defined else '' }}",
             "result": {
                 "policies": {
                     "set": {

--- a/plugins/modules/iosxr_route_maps.py
+++ b/plugins/modules/iosxr_route_maps.py
@@ -379,17 +379,23 @@ options:
                 description: MPLS traffic-eng attributeset name-string
                 type: str
               med:
-                description: Metric for Equal-Cost Multi-Path
+                description:
+                  - Metric for Equal-Cost Multi-Path
+                  - "Note: increment and decrement are mutually exclusive"
                 type: dict
                 suboptions:
                   value:
                     description: Metric value
                     type: int
                   increment:
-                    description: Increment the metric value
+                    description:
+                      - Increment the metric value
+                      - Mutually exclusive with decrement
                     type: int
                   decrement:
-                    description: Decrement the metric value
+                    description:
+                      - Decrement the metric value
+                      - Mutually exclusive with increment
                     type: int
                   igp_cost:
                     description: Use IGP metric
@@ -619,6 +625,56 @@ EXAMPLES = """
 #
 # viosxr#show running-config | include route-policy
 #
+
+- name: Configure route-policy with MED (Metric for Equal-Cost Multi-Path)
+  cisco.iosxr.iosxr_route_maps:
+    state: merged
+    config:
+      - name: MED_INCREMENT_POLICY
+        global:
+          set:
+            med:
+              increment: 50  # Increment MED by 50
+              value: 50
+      - name: MED_DECREMENT_POLICY
+        global:
+          set:
+            med:
+              decrement: 25  # Decrement MED by 25
+              value: 25
+      - name: MED_STATIC_POLICY
+        global:
+          set:
+            med:
+              value: 100  # Set MED to static value 100
+      - name: MED_IGP_COST_POLICY
+        global:
+          set:
+            med:
+              igp_cost: true  # Set MED to IGP cost
+
+# Note: increment and decrement are mutually exclusive.
+# The following would result in an error:
+#   med:
+#     increment: 50
+#     decrement: 50  # ERROR: Cannot specify both increment and decrement
+
+# Task Output
+# -----------
+#
+# commands:
+# - route-policy MED_INCREMENT_POLICY
+# - set med +50
+# - end-policy
+# - route-policy MED_DECREMENT_POLICY
+# - set med -25
+# - end-policy
+# - route-policy MED_STATIC_POLICY
+# - set med 100
+# - end-policy
+# - route-policy MED_IGP_COST_POLICY
+# - set med igp-cost
+# - end-policy
 
 - name: Merge route-policy configuration
   cisco.iosxr.iosxr_route_maps:

--- a/tests/unit/modules/network/iosxr/test_iosxr_route_maps.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_route_maps.py
@@ -475,6 +475,92 @@ class TestIosxrRouteMapsModule(TestIosxrModule):
         ]
         self.assertEqual(result["commands"], commands)
 
+    def test_set_med_increment(self):
+        self.get_config.return_value = "route-policy TEST-MED-INCREMENT"
+        self.get_config_data.return_value = ""
+        set_module_args(
+            dict(
+                config=[
+                    {
+                        "name": "TEST-MED-INCREMENT",
+                        "global": {
+                            "set": {
+                                "med": {"increment": True, "value": 50},
+                            },
+                        },
+                    },
+                ],
+                state="merged",
+            ),
+        )
+        result = self.execute_module(changed=True)
+        commands = [
+            "route-policy TEST-MED-INCREMENT",
+            "set med +50",
+            "end-policy",
+        ]
+        self.assertEqual(result["commands"], commands)
+
+    def test_set_med_decrement(self):
+        self.get_config.return_value = "route-policy TEST-MED-DECREMENT"
+        self.get_config_data.return_value = ""
+        set_module_args(
+            dict(
+                config=[
+                    {
+                        "name": "TEST-MED-DECREMENT",
+                        "global": {
+                            "set": {
+                                "med": {"decrement": True, "value": 50},
+                            },
+                        },
+                    },
+                ],
+                state="merged",
+            ),
+        )
+        result = self.execute_module(changed=True)
+        commands = [
+            "route-policy TEST-MED-DECREMENT",
+            "set med -50",
+            "end-policy",
+        ]
+        self.assertEqual(result["commands"], commands)
+
+    def test_set_med_increment_parsed(self):
+        self.get_config.return_value = "route-policy TEST-MED-PARSED"
+        self.get_config_data.return_value = dedent(
+            """\
+            route-policy TEST-MED-PARSED
+              set med +50
+            end-policy
+            """,
+        )
+        set_module_args(dict(state="gathered"))
+        result = self.execute_module(changed=False)
+        gathered = result["gathered"]
+        policy = gathered[0]
+        med = policy["global"]["set"]["med"]
+        self.assertTrue(med["increment"])
+        self.assertEqual(med["value"], 50)
+
+    def test_set_med_decrement_parsed(self):
+        self.get_config.return_value = "route-policy TEST-MED-PARSED"
+        self.get_config_data.return_value = dedent(
+            """\
+            route-policy TEST-MED-PARSED
+              set med -50
+            end-policy
+            """,
+        )
+        set_module_args(dict(state="gathered"))
+        result = self.execute_module(changed=False)
+        gathered = result["gathered"]
+        policy = gathered[0]
+        med = policy["global"]["set"]["med"]
+        self.assertTrue(med["decrement"])
+        self.assertEqual(med["value"], 50)
+
     def test_iosxr_route_maps_overridden(self):
         self.maxDiff = None
         self.get_config.return_value = dedent(

--- a/tests/unit/modules/network/iosxr/test_iosxr_route_maps.py
+++ b/tests/unit/modules/network/iosxr/test_iosxr_route_maps.py
@@ -1543,3 +1543,61 @@ class TestIosxrRouteMapsModule(TestIosxrModule):
         ]
         result = self.execute_module(changed=False)
         self.assertEqual(sorted(gathered), sorted(result["gathered"]))
+
+    def test_set_med_increment_with_space(self):
+        """Test parsing of 'set med + 50' with space between operator and value"""
+        self.get_config.return_value = "route-policy TEST-MED-SPACE"
+        self.get_config_data.return_value = dedent(
+            """\
+            route-policy TEST-MED-SPACE
+              set med + 50
+            end-policy
+            """,
+        )
+        set_module_args(dict(state="gathered"))
+        result = self.execute_module(changed=False)
+        gathered = result["gathered"]
+        policy = gathered[0]
+        med = policy["global"]["set"]["med"]
+        self.assertTrue(med["increment"])
+        self.assertEqual(med["value"], 50)
+
+    def test_set_med_decrement_with_space(self):
+        """Test parsing of 'set med - 50' with space between operator and value"""
+        self.get_config.return_value = "route-policy TEST-MED-SPACE"
+        self.get_config_data.return_value = dedent(
+            """\
+            route-policy TEST-MED-SPACE
+              set med - 50
+            end-policy
+            """,
+        )
+        set_module_args(dict(state="gathered"))
+        result = self.execute_module(changed=False)
+        gathered = result["gathered"]
+        policy = gathered[0]
+        med = policy["global"]["set"]["med"]
+        self.assertTrue(med["decrement"])
+        self.assertEqual(med["value"], 50)
+
+    def test_set_med_increment_decrement_mutual_exclusion(self):
+        """Test that increment and decrement are mutually exclusive"""
+        self.get_config.return_value = "route-policy TEST-MED-INVALID"
+        self.get_config_data.return_value = ""
+        set_module_args(
+            dict(
+                config=[
+                    {
+                        "name": "TEST-MED-INVALID",
+                        "global": {
+                            "set": {
+                                "med": {"increment": 50, "decrement": 50, "value": 50},
+                            },
+                        },
+                    },
+                ],
+                state="merged",
+            ),
+        )
+        result = self.execute_module(failed=True)
+        self.assertIn("mutually exclusive", result["msg"].lower())


### PR DESCRIPTION
## Summary
- Fix `set.med` getval regex in `Route_mapsTemplate` to correctly parse IOS-XR device-native attached-sign MED syntax (`set med +50`, `set med -50`) which was silently skipped during fact gathering
- **New**: Fix parser regex to accept both spacing formats: `set med +50` (no space) and `set med + 50` (with space between operator and value)
- Fix `setval` template to emit device-native syntax (`set med +50`) instead of `set med + 50` for round-trip fidelity
- **New**: Add `mutually_exclusive` constraint for `increment` and `decrement` options in argspec to prevent invalid configurations
- **New**: Add comprehensive documentation and examples for med options showing increment, decrement, static value, and igp_cost usage
- Add unit tests for increment/decrement MED in both merged and gathered states
- **New**: Add tests for spacing variants and mutual exclusion validation

Fixes: AAP-88911

## Changes in detail

### 1. Parser Regex Enhancement
The regex now accepts optional whitespace between operators and values:
```python
# Before:
\s*set\smed\s
(?P<increment>\+)?
(?P<decrement>\-)?
(?P<value>\d+)?

# After:
\s*set\smed\s*           # Optional space after 'med'
(?P<increment>\+)?
(?P<decrement>\-)?
\s*                      # Optional space after operator
(?P<value>\d+)?
\s*                      # Optional space after value
```

**Result**: Now correctly parses both:
- ✓ `set med +50` (no space)
- ✓ `set med + 50` (with space)
- ✓ `set med -50` and `set med - 50`

### 2. Mutual Exclusion for increment/decrement
Added argspec-level constraint:
```yaml
med:
  type: dict
  options:
    increment: {type: int}
    decrement: {type: int}
    # ... other options
  mutually_exclusive: [["increment", "decrement"]]
```

**Result**: Users get a clear error if they try to specify both increment and decrement together.

### 3. Enhanced Documentation
Added comprehensive examples in module documentation showing:
- MED with increment: `med: {increment: 50, value: 50}` → `set med +50`
- MED with decrement: `med: {decrement: 25, value: 25}` → `set med -25`
- MED with static value: `med: {value: 100}` → `set med 100`
- MED with igp_cost: `med: {igp_cost: true}` → `set med igp-cost`
- Error example showing mutual exclusion violation

## Test plan
- [x] `test_set_med_increment` — merged state generates `set med +50`
- [x] `test_set_med_decrement` — merged state generates `set med -50`
- [x] `test_set_med_increment_parsed` — gathered facts correctly parse `set med +50`
- [x] `test_set_med_decrement_parsed` — gathered facts correctly parse `set med -50`
- [x] **New**: `test_set_med_increment_with_space` — gathered facts correctly parse `set med + 50` (with space)
- [x] **New**: `test_set_med_decrement_with_space` — gathered facts correctly parse `set med - 50` (with space)
- [x] **New**: `test_set_med_increment_decrement_mutual_exclusion` — validates mutual exclusion enforcement
- [x] `test_set_med_and_extcommunity` — existing test still passes (no regression)
- [x] Full route_maps test suite — all tests pass

## Addresses reviewer feedback
This update addresses the reviewer's suggestions:
1. ✓ Parser now accepts both spacing formats (`set med +50` and `set med + 50`)
2. ✓ Mutual exclusion enforced at argspec level for increment/decrement

🤖 Generated with [Claude Code](https://claude.com/claude-code)